### PR TITLE
Options rework

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   ],
   "scripts": {
     "build": "rimraf dist && babel src --out-dir dist --extensions .ts --ignore src/**/*.test.ts && tsc --project tsconfig.build.json",
+    "lint": "yarn lint:tsc && yarn lint:eslint",
     "lint:eslint": "eslint --ext .ts utils src --max-warnings 30",
     "lint:tsc": "tsc",
     "prepublishOnly": "yarn build",

--- a/src/client.ts
+++ b/src/client.ts
@@ -17,7 +17,7 @@ import {
 } from "./download";
 import { getJSON as fileGetJSON } from "./file";
 import { getJSON, setJSON } from "./skydb";
-import { getEntry, getEntryUrl, setEntry, postSignedEntry, signEntry } from "./registry";
+import { getEntry, getEntryUrl, setEntry, postSignedEntry } from "./registry";
 import { addUrlQuery, defaultPortalUrl, makeUrl } from "./utils/url";
 import { loadMySky } from "./mysky";
 import { extractDomain, getFullDomainUrl } from "./mysky/utils";
@@ -53,8 +53,6 @@ export type RequestConfig = CustomClientOptions & {
   query?: Record<string, unknown>;
   timeout?: number; // TODO: remove
   extraPath?: string;
-  skykeyName?: string;
-  skykeyId?: string;
   headers?: Record<string, unknown>;
   transformRequest?: (data: unknown) => string;
   transformResponse?: (data: string) => Record<string, unknown>;
@@ -205,10 +203,6 @@ export class SkynetClient {
    * @throws - Will throw if unimplemented options have been passed in.
    */
   protected async executeRequest(config: RequestConfig): Promise<AxiosResponse> {
-    if (config.skykeyName || config.skykeyId) {
-      throw new Error("Unimplemented: skykeys have not been implemented in this SDK");
-    }
-
     // Build the URL.
     let url = config.url;
     if (!url) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -160,7 +160,6 @@ export class SkynetClient {
           url: this.initialPortalUrl,
           endpointPath: "/",
         }).then((response) => {
-          /* istanbul ignore next */
           if (typeof response.headers === "undefined") {
             reject(
               new Error(

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -7,6 +7,7 @@ import { sign } from "tweetnacl";
 import { RegistryEntry } from "./registry";
 import { assertUint64 } from "./utils/number";
 import { hexToUint8Array, stringToUint8Array, toHexString } from "./utils/string";
+import { validateNumber, validateString } from "./utils/validation";
 
 export type Signature = Buffer;
 
@@ -98,14 +99,8 @@ export function encodeString(str: string): Uint8Array {
  * @throws - Will throw if the inputs are not strings.
  */
 export function deriveChildSeed(masterSeed: string, seed: string): string {
-  /* istanbul ignore next */
-  if (typeof masterSeed !== "string") {
-    throw new Error(`Expected parameter masterSeed to be type string, was type ${typeof masterSeed}`);
-  }
-  /* istanbul ignore next */
-  if (typeof seed !== "string") {
-    throw new Error(`Expected parameter seed to be type string, was type ${typeof seed}`);
-  }
+  validateString("masterSeed", masterSeed, "parameter");
+  validateString("seed", seed, "parameter");
 
   return toHexString(hashAll(encodeString(masterSeed), encodeString(seed)));
 }
@@ -117,6 +112,8 @@ export function deriveChildSeed(masterSeed: string, seed: string): string {
  * @returns - The generated key pair and seed.
  */
 export function genKeyPairAndSeed(length = 64): KeyPairAndSeed {
+  validateNumber("length", length, "parameter");
+
   const seed = makeSeed(length);
   return { ...genKeyPairFromSeed(seed), seed };
 }
@@ -129,15 +126,13 @@ export function genKeyPairAndSeed(length = 64): KeyPairAndSeed {
  * @throws - Will throw if the input is not a string.
  */
 export function genKeyPairFromSeed(seed: string): KeyPair {
-  /* istanbul ignore next */
-  if (typeof seed !== "string") {
-    throw new Error(`Expected parameter seed to be type string, was type ${typeof seed}`);
-  }
+  validateString("seed", seed, "parameter");
 
   // Get a 32-byte key.
   const derivedKey = misc.pbkdf2(seed, "", 1000, 32 * 8);
   const derivedKeyHex = codec.hex.fromBits(derivedKey);
   const { publicKey, secretKey } = sign.keyPair.fromSeed(hexToUint8Array(derivedKeyHex));
+
   return { publicKey: toHexString(publicKey), privateKey: toHexString(secretKey) };
 }
 

--- a/src/download.test.ts
+++ b/src/download.test.ts
@@ -121,7 +121,7 @@ describe("getSkylinkUrl", () => {
   });
 
   it("should return correctly formed URL with forced download", async () => {
-    const url = await client.getSkylinkUrl(skylink, { download: true, endpointPath: "skynet/skylink" });
+    const url = await client.getSkylinkUrl(skylink, { download: true, endpointDownload: "skynet/skylink" });
 
     expect(url).toEqual(`${portalUrl}/skynet/skylink/${skylink}${attachment}`);
   });

--- a/src/download.ts
+++ b/src/download.ts
@@ -1,7 +1,7 @@
 import { AxiosResponse } from "axios";
 import { SkynetClient } from "./client";
 
-import { BaseCustomOptions, defaultBaseOptions, extractBaseCustomOptions } from "./utils/options";
+import { BaseCustomOptions, defaultBaseOptions } from "./utils/options";
 import { formatSkylink, uriHandshakePrefix, uriHandshakeResolverPrefix } from "./utils/skylink";
 import { trimUriPrefix } from "./utils/string";
 import { addSubdomain, addUrlQuery, getSkylinkUrlForPortal, makeUrl } from "./utils/url";
@@ -96,26 +96,6 @@ const defaultResolveHnsOptions = {
   ...defaultBaseOptions,
   endpointDownloadHnsres: "hnsres",
 };
-
-/**
- * Extract only the download custom options from the given options.
- *
- * @param opts - The given options.
- * @returns - The extracted download custom options.
- */
-export function extractDownloadOptions(opts: Record<string, unknown>): CustomDownloadOptions {
-  const baseOpts = extractBaseCustomOptions(opts);
-  const downloadOpts = (({ endpointDownload, download, noResponseMetadata, path, query, subdomain }) => ({
-    endpointDownload,
-    download,
-    noResponseMetadata,
-    path,
-    query,
-    subdomain,
-  }))(opts);
-  // @ts-expect-error - We can't ensure the correct types here.
-  return { ...baseOpts, ...downloadOpts };
-}
 
 /**
  * Initiates a download of the content of the skylink within the browser.

--- a/src/file.ts
+++ b/src/file.ts
@@ -2,6 +2,7 @@ import { SkynetClient } from "./client";
 import { deriveDiscoverableTweak } from "./mysky/tweak";
 import { CustomGetJSONOptions, JSONResponse } from "./skydb";
 import { uint8ArrayToString } from "./utils/string";
+import { validateString } from "./utils/validation";
 
 export async function getJSON(
   this: SkynetClient,
@@ -9,6 +10,9 @@ export async function getJSON(
   path: string,
   opts?: CustomGetJSONOptions
 ): Promise<JSONResponse> {
+  validateString("path", path, "parameter");
+  // Rest of validation is done in `getJSON`.
+
   const dataKey = deriveDiscoverableTweak(path);
 
   return await this.db.getJSON(userID, uint8ArrayToString(dataKey), opts);

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -1,5 +1,4 @@
 import { genKeyPairAndSeed, SkynetClient } from "./index";
-import { MAX_GET_ENTRY_TIMEOUT } from "./registry";
 import { trimPrefix } from "./utils/string";
 
 // To test a specific server, e.g. SKYNET_JS_INTEGRATION_TEST_SERVER=https://eu-fin-1.siasky.net yarn test src/integration.test.ts

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -120,30 +120,6 @@ describe(`Integration test for portal ${portal}`, () => {
 
       expect(returnedEntry).toEqual(entry);
     });
-
-    it("setEntry should not be affected by timeout parameter", async () => {
-      const { publicKey, privateKey } = genKeyPairAndSeed();
-
-      const entry = {
-        datakey: dataKey,
-        data: "bar",
-        revision: BigInt(0),
-      };
-
-      // Use a timeout of 0 (invalid, but should be ignored).
-      // @ts-expect-error We pass an invalid parameter on purpose.
-      await client.registry.setEntry(privateKey, entry, { timeout: 0 });
-      const { entry: returnedEntry } = await client.registry.getEntry(publicKey, dataKey);
-      expect(returnedEntry).toEqual(entry);
-
-      entry.revision = BigInt(1);
-
-      // Use a timeout of 301 (invalid, but should be ignored).
-      // @ts-expect-error We pass an invalid parameter on purpose.
-      await client.registry.setEntry(privateKey, entry, { timeout: MAX_GET_ENTRY_TIMEOUT + 1 });
-      const { entry: returnedEntry2 } = await client.registry.getEntry(publicKey, dataKey);
-      expect(returnedEntry2).toEqual(entry);
-    });
   });
 
   describe("Upload and download end-to-end tests", () => {

--- a/src/registry.test.ts
+++ b/src/registry.test.ts
@@ -105,12 +105,14 @@ describe("setEntry", () => {
   it("Should throw an error if the private key is not hex-encoded", async () => {
     // @ts-expect-error We pass an invalid private key on purpose.
     await expect(client.registry.setEntry("foo", {})).rejects.toThrowError(
-      "Expected parameter privateKey to be a hex-encoded string"
+      "Expected parameter 'privateKey' to be a hex-encoded string, was 'foo'"
     );
   });
 
   it("Should throw an error if the entry is not an object", async () => {
     // @ts-expect-error We do not pass an entry on purpose.
-    await expect(client.registry.setEntry(privateKey)).rejects.toThrowError("Expected parameter entry to be an object");
+    await expect(client.registry.setEntry(privateKey)).rejects.toThrowError(
+      "Expected parameter 'entry' to be type 'object', was 'undefined'"
+    );
   });
 });

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -15,7 +15,6 @@ import {
   validateOptionalObject,
   validateString,
 } from "./utils/validation";
-import { extractBaseCustomOptions } from "./utils/options";
 
 /**
  * Custom get entry options.
@@ -44,36 +43,6 @@ export const defaultSetEntryOptions = {
   ...defaultBaseOptions,
   endpointSetEntry: "/skynet/registry",
 };
-
-/**
- * Extract only the get entry custom options from the given options.
- *
- * @param opts - The given options.
- * @returns - The extracted get entry custom options.
- */
-export function extractGetEntryOptions(opts: Record<string, unknown>): CustomGetEntryOptions {
-  const baseOpts = extractBaseCustomOptions(opts);
-  const getEntryOpts = (({ endpointGetEntry }) => ({
-    endpointGetEntry,
-  }))(opts);
-  // @ts-expect-error - We can't ensure the correct types here.
-  return { ...baseOpts, ...getEntryOpts };
-}
-
-/**
- * Extract only the set entry custom options from the given options.
- *
- * @param opts - The given options.
- * @returns - The extracted set entry custom options.
- */
-export function extractSetEntryOptions(opts: Record<string, unknown>): CustomSetEntryOptions {
-  const baseOpts = extractBaseCustomOptions(opts);
-  const setEntryOpts = (({ endpointSetEntry }) => ({
-    endpointSetEntry,
-  }))(opts);
-  // @ts-expect-error - We can't ensure the correct types here.
-  return { ...baseOpts, ...setEntryOpts };
-}
 
 export const DEFAULT_GET_ENTRY_TIMEOUT = 5; // 5 seconds
 

--- a/src/skydb.test.ts
+++ b/src/skydb.test.ts
@@ -153,21 +153,21 @@ describe("setJSON", () => {
 
   it("Should throw an error if the private key is not hex-encoded", async () => {
     await expect(client.db.setJSON("foo", dataKey, {})).rejects.toThrowError(
-      "Expected parameter privateKey to be a hex-encoded string"
+      "Expected parameter 'privateKey' to be a hex-encoded string, was 'foo'"
     );
   });
 
   it("Should throw an error if the data key is not provided", async () => {
     // @ts-expect-error We do not pass the datakey on purpose.
     await expect(client.db.setJSON(privateKey)).rejects.toThrowError(
-      "Expected parameter dataKey to be type string, was type undefined"
+      "Expected parameter 'dataKey' to be type 'string', was 'undefined'"
     );
   });
 
   it("Should throw an error if the json is not provided", async () => {
     // @ts-expect-error We do not pass the json on purpose.
     await expect(client.db.setJSON(privateKey, dataKey)).rejects.toThrowError(
-      "Expected parameter json to be an object"
+      "Expected parameter 'json' to be type 'object', was 'undefined'"
     );
   });
 });

--- a/src/skydb.ts
+++ b/src/skydb.ts
@@ -68,13 +68,14 @@ export async function getJSON(
   // Rest of validation is done in `getEntry`.
 
   const opts = {
-    ...defaultGetEntryOptions,
+    ...defaultGetJSONOptions,
     ...this.customOptions,
     ...customOptions,
   };
 
   // Lookup the registry entry.
-  const { entry }: { entry: RegistryEntry | null } = await this.registry.getEntry(publicKey, dataKey, opts);
+  const getEntryOpts = extractGetEntryOptions(opts);
+  const { entry }: { entry: RegistryEntry | null } = await this.registry.getEntry(publicKey, dataKey, getEntryOpts);
   if (entry === null) {
     return { data: null, skylink: null };
   }
@@ -123,7 +124,7 @@ export async function setJSON(
   validateOptionalObject("customOptions", customOptions, "parameter", defaultSetJSONOptions);
 
   const opts = {
-    ...defaultSetEntryOptions,
+    ...defaultSetJSONOptions,
     ...this.customOptions,
     ...customOptions,
   };

--- a/src/upload.test.ts
+++ b/src/upload.test.ts
@@ -139,10 +139,14 @@ describe("uploadFile", () => {
 
   it("Trying to upload with a skykey should throw an error", async () => {
     // @ts-expect-error we only check this use case in case someone ignores typescript typing
-    await expect(client.uploadFile(file, { skykeyName: "test" })).rejects.toThrow();
+    await expect(client.uploadFile(file, { skykeyName: "test" })).rejects.toThrow(
+      "Object parameter 'customOptions' contains unexpected property 'skykeyName'"
+    );
 
     // @ts-expect-error we only check this use case in case someone ignores typescript typing
-    await expect(client.uploadFile(file, { skykeyId: "test" })).rejects.toThrow();
+    await expect(client.uploadFile(file, { skykeyId: "test" })).rejects.toThrow(
+      "Object parameter 'customOptions' contains unexpected property 'skykeyId'"
+    );
   });
 
   it("should throw if a skylink was not returned", async () => {

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -10,7 +10,6 @@ import {
   validateOptionalObject,
   validateString,
 } from "./utils/validation";
-import { extractBaseCustomOptions } from "./utils/options";
 
 /**
  * Custom upload options.
@@ -50,31 +49,6 @@ export const defaultUploadOptions = {
   customFilename: "",
   query: undefined,
 };
-
-/**
- * Extract only the upload custom options from the given options.
- *
- * @param opts - The given options.
- * @returns - The extracted upload custom options.
- */
-export function extractUploadOptions(opts: Record<string, unknown>): CustomUploadOptions {
-  const baseOpts = extractBaseCustomOptions(opts);
-  const uploadOpts = (({
-    endpointUpload,
-    portalFileFieldname,
-    portalDirectoryFileFieldname,
-    customFilename,
-    query,
-  }) => ({
-    endpointUpload,
-    portalFileFieldname,
-    portalDirectoryFileFieldname,
-    customFilename,
-    query,
-  }))(opts);
-  // @ts-expect-error - We can't ensure the correct types here.
-  return { ...baseOpts, ...uploadOpts };
-}
 
 /**
  * Uploads a file to Skynet.

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -1,5 +1,5 @@
 import { getFileMimeType } from "./utils/file";
-import { BaseCustomOptions, defaultOptions } from "./utils/options";
+import { BaseCustomOptions, defaultBaseOptions } from "./utils/options";
 import { formatSkylink } from "./utils/skylink";
 import { SkynetClient } from "./client";
 import { AxiosResponse } from "axios";
@@ -15,12 +15,14 @@ import { extractBaseCustomOptions } from "./utils/options";
 /**
  * Custom upload options.
  *
+ * @property [endpointUpload] - The relative URL path of the portal endpoint to contact.
  * @property [portalFileFieldname="file"] - The file fieldname for uploading files on this portal.
  * @property [portalDirectoryfilefieldname="files[]"] - The file fieldname for uploading directories on this portal.
  * @property [customFilename] - The custom filename to use when uploading files.
  * @property [query] - Query parameters. Allows passing in parameters that haven't been implemented in the SDK yet.
  */
 export type CustomUploadOptions = BaseCustomOptions & {
+  endpointUpload?: string;
   portalFileFieldname?: string;
   portalDirectoryFileFieldname?: string;
   customFilename?: string;
@@ -41,22 +43,36 @@ export type UploadRequestResponse = {
 };
 
 export const defaultUploadOptions = {
-  ...defaultOptions("/skynet/skyfile"),
+  ...defaultBaseOptions,
+  endpointUpload: "/skynet/skyfile",
   portalFileFieldname: "file",
   portalDirectoryFileFieldname: "files[]",
   customFilename: "",
   query: undefined,
 };
 
+/**
+ * Extract only the upload custom options from the given options.
+ *
+ * @param opts - The given options.
+ * @returns - The extracted upload custom options.
+ */
 export function extractUploadOptions(opts: Record<string, unknown>): CustomUploadOptions {
   const baseOpts = extractBaseCustomOptions(opts);
-  const uploadOpts = (({ portalFileFieldname, portalDirectoryFileFieldname, customFilename, query }) => ({
+  const uploadOpts = (({
+    endpointUpload,
+    portalFileFieldname,
+    portalDirectoryFileFieldname,
+    customFilename,
+    query,
+  }) => ({
+    endpointUpload,
     portalFileFieldname,
     portalDirectoryFileFieldname,
     customFilename,
     query,
   }))(opts);
-  // @ts-expect-error
+  // @ts-expect-error - We can't ensure the correct types here.
   return { ...baseOpts, ...uploadOpts };
 }
 
@@ -118,6 +134,7 @@ export async function uploadFileRequest(
 
   const response = await this.executeRequest({
     ...opts,
+    endpointPath: opts.endpointUpload,
     method: "post",
     data: formData,
   });
@@ -187,6 +204,7 @@ export async function uploadDirectoryRequest(
 
   const response = await this.executeRequest({
     ...opts,
+    endpointPath: opts.endpointUpload,
     method: "post",
     data: formData,
     query: { filename },

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -214,9 +214,9 @@ function validateUploadResponse(response: AxiosResponse): void {
       throw new Error("response.data field missing");
     }
 
-    validateString("response.data.skylink", response.data.skylink, "upload response field");
-    validateString("response.data.merkleroot", response.data.merkleroot, "upload response field");
-    validateNumber("response.data.bitfield", response.data.bitfield, "upload response field");
+    validateString("skylink", response.data.skylink, "upload response field");
+    validateString("merkleroot", response.data.merkleroot, "upload response field");
+    validateNumber("bitfield", response.data.bitfield, "upload response field");
   } catch (err) {
     throw new Error(
       `Did not get a complete upload response despite a successful request. Please try again and report this issue to the devs if it persists. Error: ${err}`

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -1,3 +1,5 @@
+import { validateBigint } from "./validation";
+
 /**
  * The maximum allowed value for an entry revision. Setting an entry revision to this value prevents it from being updated further.
  */
@@ -11,10 +13,7 @@ export const MAX_REVISION = BigInt("18446744073709551615"); // max uint64
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/asUintN | MDN Demo}
  */
 export function assertUint64(int: bigint): void {
-  /* istanbul ignore next */
-  if (typeof int !== "bigint") {
-    throw new Error(`Expected parameter int to be type bigint, was type ${typeof int}`);
-  }
+  validateBigint("int", int, "parameter");
 
   if (int < BigInt(0)) {
     throw new Error(`Argument ${int} must be an unsigned 64-bit integer; was negative`);

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -15,16 +15,19 @@ export const defaultBaseOptions = {
 };
 
 /**
- * Extract only the base custom options from the given options.
+ * Extract only the model's custom options from the given options.
  *
  * @param opts - The given options.
- * @returns - The extracted base custom options.
+ * @param model - The model options.
+ * @returns - The extracted custom options.
  */
-export function extractBaseCustomOptions(opts: Record<string, unknown>): BaseCustomOptions {
-  // @ts-expect-error - We can't ensure the correct types here.
-  return (({ APIKey, customUserAgent, onUploadProgress }) => ({
-    APIKey,
-    customUserAgent,
-    onUploadProgress,
-  }))(opts);
+export function extractOptions<T extends Record<string, unknown>>(opts: Record<string, unknown>, model: T): T {
+  const result: Record<string, unknown> = {};
+  for (const property in model) {
+    if (Object.prototype.hasOwnProperty.call(model, property)) {
+      result[property] = opts[property];
+    }
+  }
+
+  return result as T;
 }

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -2,32 +2,27 @@ import { CustomClientOptions } from "../client";
 
 /**
  * Base custom options for methods hitting the API.
- *
- * @property [endpointPath] - The relative URL path of the portal endpoint to contact.
  */
-export type BaseCustomOptions = CustomClientOptions & {
-  endpointPath?: string;
+export type BaseCustomOptions = CustomClientOptions;
+
+/**
+ * The default base custom options.
+ */
+export const defaultBaseOptions = {
+  APIKey: "",
+  customUserAgent: "",
+  onUploadProgress: undefined,
 };
 
 /**
- * Returns the default base custom options for the given endpoint path.
+ * Extract only the base custom options from the given options.
  *
- * @param endpointPath - The endpoint path.
- * @returns - The base custom options.
+ * @param opts - The given options.
+ * @returns - The extracted base custom options.
  */
-export function defaultOptions(endpointPath: string): CustomClientOptions & { endpointPath: string } {
-  return {
-    endpointPath,
-    APIKey: "",
-    customUserAgent: "",
-    onUploadProgress: undefined,
-  };
-}
-
 export function extractBaseCustomOptions(opts: Record<string, unknown>): BaseCustomOptions {
-  // @ts-expect-error
-  return (({ endpointPath, APIKey, customUserAgent, onUploadProgress }) => ({
-    endpointPath,
+  // @ts-expect-error - We can't ensure the correct types here.
+  return (({ APIKey, customUserAgent, onUploadProgress }) => ({
     APIKey,
     customUserAgent,
     onUploadProgress,

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -1,0 +1,35 @@
+import { CustomClientOptions } from "../client";
+
+/**
+ * Base custom options for methods hitting the API.
+ *
+ * @property [endpointPath] - The relative URL path of the portal endpoint to contact.
+ */
+export type BaseCustomOptions = CustomClientOptions & {
+  endpointPath?: string;
+};
+
+/**
+ * Returns the default base custom options for the given endpoint path.
+ *
+ * @param endpointPath - The endpoint path.
+ * @returns - The base custom options.
+ */
+export function defaultOptions(endpointPath: string): CustomClientOptions & { endpointPath: string } {
+  return {
+    endpointPath,
+    APIKey: "",
+    customUserAgent: "",
+    onUploadProgress: undefined,
+  };
+}
+
+export function extractBaseCustomOptions(opts: Record<string, unknown>): BaseCustomOptions {
+  // @ts-expect-error
+  return (({ endpointPath, APIKey, customUserAgent, onUploadProgress }) => ({
+    endpointPath,
+    APIKey,
+    customUserAgent,
+    onUploadProgress,
+  }))(opts);
+}

--- a/src/utils/skylink.test.ts
+++ b/src/utils/skylink.test.ts
@@ -65,9 +65,9 @@ describe("parseSkylink", () => {
 
   it("should return null on invalid skylink", () => {
     // @ts-expect-error we only check this use case in case someone ignores typescript typing
-    expect(() => parseSkylink()).toThrowError("Skylink has to be a string, undefined provided");
+    expect(() => parseSkylink()).toThrowError("Expected parameter 'skylinkUrl' to be type 'string', was 'undefined'");
     // @ts-expect-error we only check this use case in case someone ignores typescript typing
-    expect(() => parseSkylink(123)).toThrowError("Skylink has to be a string, number provided");
+    expect(() => parseSkylink(123)).toThrowError("Expected parameter 'skylinkUrl' to be type 'string', was '123'");
   });
 
   const invalidCases = ["123", `${skylink}xxx`, `${skylink}xxx/foo`, `${skylink}xxx?foo`];

--- a/src/utils/skylink.ts
+++ b/src/utils/skylink.ts
@@ -3,15 +3,7 @@ import base32Encode from "base32-encode";
 import parse from "url-parse";
 import { CustomClientOptions } from "../client";
 import { trimForwardSlash, trimSuffix, trimUriPrefix } from "./string";
-
-/**
- * Base custom options for methods hitting the API.
- *
- * @property [endpointPath] - The relative URL path of the portal endpoint to contact.
- */
-export type BaseCustomOptions = CustomClientOptions & {
-  endpointPath?: string;
-};
+import { validateOptionalObject, validateString } from "./validation";
 
 /**
  * Parse skylink options.
@@ -26,8 +18,10 @@ export type ParseSkylinkOptions = {
   onlyPath?: boolean;
 };
 
-type ParseSkylinkBase32Options = {
-  onlyPath?: boolean;
+const defaultParseSkylinkOptions = {
+  fromSubdomain: false,
+  includePath: false,
+  onlyPath: false,
 };
 
 export const uriHandshakePrefix = "hns:";
@@ -43,20 +37,6 @@ export const uriSkynetPrefix = "sia:";
 export function convertSkylinkToBase32(skylink: string): string {
   const decoded = base64.toByteArray(skylink.padEnd(skylink.length + 4 - (skylink.length % 4), "="));
   return base32Encode(decoded, "RFC4648-HEX", { padding: false }).toLowerCase();
-}
-
-/**
- * Returns the default base custom options for the given endpoint path.
- *
- * @param endpointPath - The endpoint path.
- * @returns - The base custom options.
- */
-export function defaultOptions(endpointPath: string): CustomClientOptions & { endpointPath: string } {
-  return {
-    endpointPath,
-    APIKey: "",
-    customUserAgent: "",
-  };
 }
 
 /**
@@ -87,12 +67,15 @@ const SKYLINK_PATH_MATCH_POSITION = 2;
  * Parses the given string for a base64 skylink, or base32 if opts.fromSubdomain is given. If the given string is prefixed with sia:, sia://, or a portal URL, those will be removed and the raw skylink returned.
  *
  * @param skylinkUrl - Plain skylink, skylink with URI prefix, or URL with skylink as the first path element.
- * @param [opts] - Additional settings that can optionally be set.
+ * @param [customOptions] - Additional settings that can optionally be set.
  * @returns - The base64 (or base32) skylink, optionally with the path included.
  * @throws - Will throw on invalid combination of options.
  */
-export function parseSkylink(skylinkUrl: string, opts: ParseSkylinkOptions = {}): string | null {
-  if (typeof skylinkUrl !== "string") throw new Error(`Skylink has to be a string, ${typeof skylinkUrl} provided`);
+export function parseSkylink(skylinkUrl: string, customOptions?: ParseSkylinkOptions): string | null {
+  validateString("skylinkUrl", skylinkUrl, "parameter");
+  validateOptionalObject("customOptions", customOptions, "parameter", defaultParseSkylinkOptions);
+
+  const opts = { ...defaultParseSkylinkOptions, ...customOptions };
 
   if (opts.includePath && opts.onlyPath) {
     throw new Error("The includePath and onlyPath options cannot both be set");
@@ -138,13 +121,17 @@ export function parseSkylink(skylinkUrl: string, opts: ParseSkylinkOptions = {})
 }
 
 /**
- * Parses the given string for a base32 skylink.
+ * Helper function that parses the given string for a base32 skylink.
  *
  * @param skylinkUrl - Base32 skylink.
- * @param [opts] - Additional settings that can optionally be set.
+ * @param [customOptions] - Additional settings that can optionally be set.
  * @returns - The base32 skylink.
  */
-export function parseSkylinkBase32(skylinkUrl: string, opts: ParseSkylinkBase32Options = {}): string | null {
+export function parseSkylinkBase32(skylinkUrl: string, customOptions?: ParseSkylinkOptions): string | null {
+  // Do not validate, this helper function should only be called from parseSkylink.
+
+  const opts = { ...defaultParseSkylinkOptions, ...customOptions };
+
   // Pass empty object as second param to disable using location as base url
   // when parsing in browser.
   const parsed = parse(skylinkUrl, {});

--- a/src/utils/skylink.ts
+++ b/src/utils/skylink.ts
@@ -1,7 +1,6 @@
 import base64 from "base64-js";
 import base32Encode from "base32-encode";
 import parse from "url-parse";
-import { CustomClientOptions } from "../client";
 import { trimForwardSlash, trimSuffix, trimUriPrefix } from "./string";
 import { validateOptionalObject, validateString } from "./validation";
 

--- a/src/utils/string.test.ts
+++ b/src/utils/string.test.ts
@@ -44,7 +44,9 @@ describe("hexToUint8Array", () => {
   const invalidHexStrings = ["xyz", "aabbzz", ""];
 
   it.each(invalidHexStrings)("should throw on invalid input '%s'", (str) => {
-    expect(() => hexToUint8Array(str)).toThrowError(`Expected parameter 'str' to be a hex-encoded string, was '${str}'`);
+    expect(() => hexToUint8Array(str)).toThrowError(
+      `Expected parameter 'str' to be a hex-encoded string, was '${str}'`
+    );
   });
 });
 

--- a/src/utils/string.test.ts
+++ b/src/utils/string.test.ts
@@ -44,7 +44,7 @@ describe("hexToUint8Array", () => {
   const invalidHexStrings = ["xyz", "aabbzz", ""];
 
   it.each(invalidHexStrings)("should throw on invalid input '%s'", (str) => {
-    expect(() => hexToUint8Array(str)).toThrowError(`Input string '${str}' is not a valid hex-encoded string`);
+    expect(() => hexToUint8Array(str)).toThrowError(`Expected parameter 'str' to be a hex-encoded string, was '${str}'`);
   });
 });
 

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,5 +1,7 @@
 import { Buffer } from "buffer";
 
+import { throwValidationError, validateHexString, validateString } from "./validation";
+
 /**
  * Removes a prefix from the beginning of the string.
  *
@@ -80,10 +82,7 @@ export function trimUriPrefix(str: string, prefix: string): string {
  * @throws - Will throw if the input is not a string.
  */
 export function stringToUint8Array(str: string): Uint8Array {
-  /* istanbul ignore next */
-  if (typeof str !== "string") {
-    throw new Error(`Expected parameter str to be type string, was type ${typeof str}`);
-  }
+  validateString("str", str, "parameter");
 
   return Uint8Array.from(Buffer.from(str));
 }
@@ -106,13 +105,13 @@ export function uint8ArrayToString(array: Uint8Array): string {
  * @throws - Will throw if the input is not a valid hex-encoded string or is an empty string.
  */
 export function hexToUint8Array(str: string): Uint8Array {
-  if (!isHexString(str)) {
-    throw new Error(`Input string '${str}' is not a valid hex-encoded string`);
-  }
+  validateHexString("str", str, "parameter");
+
   const matches = str.match(/.{1,2}/g);
   if (matches === null) {
-    throw new Error(`Input string '${str}' is not a valid hex-encoded string`);
+    throw throwValidationError("str", str, "parameter", "a hex-encoded string");
   }
+
   return new Uint8Array(matches.map((byte) => parseInt(byte, 16)));
 }
 
@@ -124,10 +123,7 @@ export function hexToUint8Array(str: string): Uint8Array {
  * @throws - Will throw if the input is not a string.
  */
 export function isHexString(str: string): boolean {
-  /* istanbul ignore next */
-  if (typeof str !== "string") {
-    throw new Error(`Expected parameter str to be type string, was type ${typeof str}`);
-  }
+  validateString("str", str, "parameter");
 
   return /^[0-9A-Fa-f]*$/g.test(str);
 }

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -2,10 +2,11 @@ import parse from "url-parse";
 import urljoin from "url-join";
 
 import { isHexString, toHexString, trimPrefix, trimSuffix } from "./string";
-import { defaultGetEntryOptions, CustomGetEntryOptions, MAX_GET_ENTRY_TIMEOUT } from "../registry";
+import { defaultGetEntryOptions, CustomGetEntryOptions, DEFAULT_GET_ENTRY_TIMEOUT } from "../registry";
 import { hashDataKey } from "../crypto";
 import { defaultDownloadOptions, CustomDownloadOptions } from "../download";
 import { convertSkylinkToBase32, parseSkylink } from "./skylink";
+import { validateOptionalObject, validateString } from "./validation";
 
 export const defaultSkynetPortalUrl = "https://siasky.net";
 
@@ -78,31 +79,15 @@ export function getEntryUrlForPortal(
   dataKey: string,
   customOptions?: CustomGetEntryOptions
 ): string {
-  /* istanbul ignore next */
-  if (typeof portalUrl !== "string") {
-    throw new Error(`Expected parameter 'portalUrl' to be type string, was type ${typeof portalUrl}`);
-  }
-  /* istanbul ignore next */
-  if (typeof publicKey !== "string") {
-    throw new Error(`Expected parameter 'publicKey' to be type string, was type ${typeof publicKey}`);
-  }
-  /* istanbul ignore next */
-  if (typeof dataKey !== "string") {
-    throw new Error(`Expected parameter 'dataKey' to be type string, was type ${typeof dataKey}`);
-  }
+  validateString("portalUrl", portalUrl, "parameter");
+  validateString("publicKey", publicKey, "parameter");
+  validateString("dataKey", dataKey, "parameter");
+  validateOptionalObject("customOptions", customOptions, "parameter", defaultGetEntryOptions);
 
   const opts = {
     ...defaultGetEntryOptions,
     ...customOptions,
   };
-
-  const timeout = opts.timeout;
-
-  if (!Number.isInteger(timeout) || timeout > MAX_GET_ENTRY_TIMEOUT || timeout < 1) {
-    throw new Error(
-      `Invalid 'timeout' parameter '${timeout}', needs to be an integer between 1s and ${MAX_GET_ENTRY_TIMEOUT}s`
-    );
-  }
 
   // Trim the prefix if it was passed in.
   publicKey = trimPrefix(publicKey, "ed25519:");
@@ -116,7 +101,7 @@ export function getEntryUrlForPortal(
   const query = {
     publickey: `ed25519:${publicKey}`,
     datakey: dataKeyHash,
-    timeout,
+    timeout: DEFAULT_GET_ENTRY_TIMEOUT,
   };
 
   let url = makeUrl(portalUrl, opts.endpointPath);
@@ -139,14 +124,9 @@ export function getSkylinkUrlForPortal(
   skylinkUrl: string,
   customOptions?: CustomDownloadOptions
 ): string {
-  /* istanbul ignore next */
-  if (typeof portalUrl !== "string") {
-    throw new Error(`Expected parameter 'portalUrl' to be type string, was type ${typeof portalUrl}`);
-  }
-  /* istanbul ignore next */
-  if (typeof skylinkUrl !== "string") {
-    throw new Error(`Expected parameter skylinkUrl to be type string, was type ${typeof skylinkUrl}`);
-  }
+  validateString("portalUrl", portalUrl, "parameter");
+  validateString("skylinkUrl", skylinkUrl, "parameter");
+  validateOptionalObject("customOptions", customOptions, "parameter", defaultDownloadOptions);
 
   const opts = { ...defaultDownloadOptions, ...customOptions };
 
@@ -212,6 +192,9 @@ export function getSkylinkUrlForPortal(
  * @returns - The full URL for the given domain.
  */
 export function getFullDomainUrlForPortal(portalUrl: string, domain: string): string {
+  validateString("portalUrl", portalUrl, "parameter");
+  validateString("domain", domain, "parameter");
+
   domain = trimSuffix(domain, "/");
   return addSubdomain(portalUrl, domain);
 }
@@ -222,10 +205,13 @@ export function getFullDomainUrlForPortal(portalUrl: string, domain: string): st
  * e.g. ("https://siasky.net", "dac.hns.siasky.net") => "dac.hns"
  *
  * @param portalUrl - The portal URL.
- * @param fullUrl - Full URL.
+ * @param fullDomain - Full URL.
  * @returns - The extracted domain.
  */
 export function extractDomainForPortal(portalUrl: string, fullDomain: string): string {
+  validateString("portalUrl", portalUrl, "parameter");
+  validateString("fullDomain", fullDomain, "parameter");
+
   const portalUrlObj = new URL(portalUrl);
   const portalDomain = portalUrlObj.hostname;
 

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -6,7 +6,7 @@ import { defaultGetEntryOptions, CustomGetEntryOptions, DEFAULT_GET_ENTRY_TIMEOU
 import { hashDataKey } from "../crypto";
 import { defaultDownloadOptions, CustomDownloadOptions } from "../download";
 import { convertSkylinkToBase32, parseSkylink } from "./skylink";
-import { validateOptionalObject, validateString } from "./validation";
+import { throwValidationError, validateOptionalObject, validateString } from "./validation";
 
 export const defaultSkynetPortalUrl = "https://siasky.net";
 
@@ -60,6 +60,9 @@ export function addUrlQuery(url: string, query: Record<string, unknown>): string
  * @returns - Final URL constructed from the input parts.
  */
 export function makeUrl(...args: string[]): string {
+  if (args.length === 0) {
+    throwValidationError("args", args, "parameter", "non-empty");
+  }
   return args.reduce((acc, cur) => urljoin(acc, cur));
 }
 
@@ -104,7 +107,7 @@ export function getEntryUrlForPortal(
     timeout: DEFAULT_GET_ENTRY_TIMEOUT,
   };
 
-  let url = makeUrl(portalUrl, opts.endpointPath);
+  let url = makeUrl(portalUrl, opts.endpointGetEntry);
   url = addUrlQuery(url, query);
 
   return url;
@@ -178,7 +181,7 @@ export function getSkylinkUrlForPortal(
       throw new Error(`Could not get skylink with path out of input '${skylinkUrl}'`);
     }
     // Add additional path if passed in.
-    url = makeUrl(portalUrl, opts.endpointPath, skylink, path);
+    url = makeUrl(portalUrl, opts.endpointDownload, skylink, path);
   }
   return addUrlQuery(url, query);
 }

--- a/src/utils/validation.test.ts
+++ b/src/utils/validation.test.ts
@@ -1,0 +1,17 @@
+import { validateBigint, validateObject } from "./validation";
+
+describe("validateBigint", () => {
+  it("validateBigint should catch non-bigint input", () => {
+    expect(() => validateBigint("test", 123, "parameter")).toThrowError(
+      "Expected parameter 'test' to be type 'bigint', was '123'"
+    );
+  });
+});
+
+describe("validateObject", () => {
+  it("validateObject should catch null input", () => {
+    expect(() => validateObject("test", null, "parameter")).toThrowError(
+      "Expected parameter 'test' to be non-null, was 'null'"
+    );
+  });
+});

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,117 @@
+import { isHexString } from "./string";
+
+/**
+ * Validates the given value as a bigint.
+ *
+ * @param name - The name of the value.
+ * @param value - The actual value.
+ * @param valueKind - The kind of value that is being checked (e.g. "parameter", "response field", etc.)
+ * @throws - Will throw if not a valid bigint.
+ */
+export function validateBigint(name: string, value: unknown, valueKind: string): void {
+  if (typeof value !== "bigint") {
+    throwValidationError(name, value, valueKind, "type 'bigint'");
+  }
+}
+
+/**
+ * Validates the given value as an object.
+ *
+ * @param name - The name of the value.
+ * @param value - The actual value.
+ * @param valueKind - The kind of value that is being checked (e.g. "parameter", "response field", etc.)
+ * @throws - Will throw if not a valid object.
+ */
+export function validateObject(name: string, value: unknown, valueKind: string): void {
+  if (typeof value !== "object") {
+    throwValidationError(name, value, valueKind, "type 'object'");
+  }
+  if (value === null) {
+    throwValidationError(name, value, valueKind, "non-null");
+  }
+}
+
+/**
+ * Validates the given value as an optional object.
+ *
+ * @param name - The name of the value.
+ * @param value - The actual value.
+ * @param valueKind - The kind of value that is being checked (e.g. "parameter", "response field", etc.)
+ * @param model - A model object that contains all possible fields. 'value' does not need to have all fields, but it may not have any fields not contained in 'model'.
+ * @throws - Will throw if not a valid optional object.
+ */
+export function validateOptionalObject(
+  name: string,
+  value: unknown,
+  valueKind: string,
+  model: Record<string, unknown>
+): void {
+  if (!value) {
+    // This is okay, the object is optional.
+    return;
+  }
+  validateObject(name, value, valueKind);
+
+  // Check if all given properties of value also exist in the model.
+  for (const property in value as Record<string, unknown>) {
+    if (!(property in model)) {
+      throw new Error(`Object ${valueKind} '${name}' contains unexpected property '${property}'`);
+    }
+  }
+}
+
+/**
+ * Validates the given value as a number.
+ *
+ * @param name - The name of the value.
+ * @param value - The actual value.
+ * @param valueKind - The kind of value that is being checked (e.g. "parameter", "response field", etc.)
+ * @throws - Will throw if not a valid number.
+ */
+export function validateNumber(name: string, value: unknown, valueKind: string): void {
+  if (typeof value !== "number") {
+    throwValidationError(name, value, valueKind, "type 'number'");
+  }
+}
+
+/**
+ * Validates the given value as a string.
+ *
+ * @param name - The name of the value.
+ * @param value - The actual value.
+ * @param valueKind - The kind of value that is being checked (e.g. "parameter", "response field", etc.)
+ * @throws - Will throw if not a valid string.
+ */
+export function validateString(name: string, value: unknown, valueKind: string): void {
+  if (typeof value !== "string") {
+    throwValidationError(name, value, valueKind, "type 'string'");
+  }
+}
+
+/**
+ * Validates the given value as a hex-encoded string.
+ *
+ * @param name - The name of the value.
+ * @param value - The actual value.
+ * @param valueKind - The kind of value that is being checked (e.g. "parameter", "response field", etc.)
+ * @throws - Will throw if not a valid hex-encoded string.
+ */
+export function validateHexString(name: string, value: unknown, valueKind: string): void {
+  validateString(name, value, valueKind);
+  if (!isHexString(value as string)) {
+    throwValidationError(name, value, valueKind, "a hex-encoded string");
+  }
+}
+
+/**
+ * Throws an error for the given value
+ *
+ * @param name - The name of the value.
+ * @param value - The actual value.
+ * @param valueKind - The kind of value that is being checked (e.g. "parameter", "response field", etc.)
+ * @param expected - The expected aspect of the value that could not be validated (e.g. "type 'string'" or "non-null").
+ * @throws - Will always throw.
+ */
+export function throwValidationError(name: string, value: unknown, valueKind: string, expected: string): void {
+  throw new Error(`Expected ${valueKind} '${name}' to be ${expected}, was '${value}'`);
+}


### PR DESCRIPTION
Commit 1:
- [BREAKING] Removed getEntry 'timeout' option.
- Added input validation functions.
- Moved base options to 'utils/options.ts' file.

Commit 2:
- Rework generic 'endpoint' option to be specific for every endpoint (e.g. endpointGetEntry).

Closes #19