### PR TITLE
Re-export Permission from skynet-mysky-utils

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,17 @@ export {
   getSkylinkUrlForPortal,
 } from "./utils/url";
 export { DacLibrary, mySkyDomain, mySkyDevDomain } from "./mysky";
+// Re-export Permissions.
+export {
+  Permission,
+  PermCategory,
+  PermType,
+  PermRead,
+  PermWrite,
+  PermHidden,
+  PermDiscoverable,
+  PermLegacySkyID,
+} from "skynet-mysky-utils";
 
 // Export types.
 


### PR DESCRIPTION
Just realized that you can't call `mysky.addPermissions()` without the `Permission` class from `skynet-mysky-utils`. I re-export it from `skynet-js` to avoid devs having to set an extra dependency.