### PR TITLE
Custom Cookie Option

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -28,11 +28,13 @@ import { trimSuffix } from "./utils/string";
  *
  * @property [APIKey] - Authentication password to use.
  * @property [customUserAgent] - Custom user agent header to set.
+ * @property [customCookie] - Custom cookie header to set.
  * @property [onUploadProgress] - Optional callback to track upload progress.
  */
 export type CustomClientOptions = {
   APIKey?: string;
   customUserAgent?: string;
+  customCookie?: string;
   onUploadProgress?: (progress: number, event: ProgressEvent) => void;
 };
 
@@ -219,6 +221,9 @@ export class SkynetClient {
     const headers = { ...config.headers };
     if (config.customUserAgent) {
       headers["User-Agent"] = config.customUserAgent;
+    }
+    if (config.customCookie) {
+      headers["Cookie"] = config.customCookie
     }
 
     const auth = config.APIKey ? { username: "", password: config.APIKey } : undefined;

--- a/src/client.ts
+++ b/src/client.ts
@@ -223,7 +223,7 @@ export class SkynetClient {
       headers["User-Agent"] = config.customUserAgent;
     }
     if (config.customCookie) {
-      headers["Cookie"] = config.customCookie
+      headers["Cookie"] = config.customCookie;
     }
 
     const auth = config.APIKey ? { username: "", password: config.APIKey } : undefined;

--- a/src/skydb.ts
+++ b/src/skydb.ts
@@ -15,7 +15,7 @@ import { hexToUint8Array, trimUriPrefix, toHexString, stringToUint8ArrayUtf8 } f
 import { defaultUploadOptions, CustomUploadOptions, UploadRequestResponse } from "./upload";
 import { defaultDownloadOptions, CustomDownloadOptions } from "./download";
 import { validateHexString, validateObject, validateOptionalObject, validateString } from "./utils/validation";
-import { extractOptions } from "./utils/options";
+import { defaultBaseOptions, extractOptions } from "./utils/options";
 
 export const JSON_RESPONSE_VERSION = 2;
 
@@ -32,6 +32,7 @@ export type CustomGetJSONOptions = CustomGetEntryOptions &
   };
 
 export const defaultGetJSONOptions = {
+  ...defaultBaseOptions,
   ...defaultGetEntryOptions,
   ...defaultDownloadOptions,
   cachedDataLink: undefined,
@@ -43,6 +44,7 @@ export const defaultGetJSONOptions = {
 export type CustomSetJSONOptions = CustomGetJSONOptions & CustomSetEntryOptions & CustomUploadOptions;
 
 export const defaultSetJSONOptions = {
+  ...defaultBaseOptions,
   ...defaultGetJSONOptions,
   ...defaultSetEntryOptions,
   ...defaultUploadOptions,

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -11,6 +11,7 @@ export type BaseCustomOptions = CustomClientOptions;
 export const defaultBaseOptions = {
   APIKey: "",
   customUserAgent: "",
+  customCookie: "",
   onUploadProgress: undefined,
 };
 


### PR DESCRIPTION
This PR adds a `customCookie` option to the client options. This allows using accounts. Now I know this is not ideal because of API keys, I thought about adding custom headers but the problem is there it's inconsistent with `customUserAgent`, because it would make that redundant.

This is just a proposal PR. Up for discussion, but I wanted to type it up already.