### PR TITLE
pass sanitized copy of permissions array

### DIFF
--- a/src/mysky/index.ts
+++ b/src/mysky/index.ts
@@ -191,7 +191,7 @@ export class MySky {
 
         // Slightly hacky, but this copies permissions array so that Proxy objects
         // used in frameworks like Vuex don't try to pass through postMessage.
-        const perms =JSON.parse ( JSON.stringify ( this.pendingPermissions) );
+        const perms = JSON.parse(JSON.stringify(this.pendingPermissions));
 
         // TODO: This should be a dual-promise that also calls ping() on an interval and rejects if no response was found in a given amount of time.
         const [seedFoundResponse, permissionsResponse]: [

--- a/src/mysky/index.ts
+++ b/src/mysky/index.ts
@@ -189,11 +189,15 @@ export class MySky {
 
         // Send the UI the list of required permissions.
 
+        // Slightly hacky, but this copies permissions array so that Proxy objects
+        // used in frameworks like Vuex don't try to pass through postMessage.
+        const perms =JSON.parse ( JSON.stringify ( this.pendingPermissions) );
+
         // TODO: This should be a dual-promise that also calls ping() on an interval and rejects if no response was found in a given amount of time.
         const [seedFoundResponse, permissionsResponse]: [
           boolean,
           CheckPermissionsResponse
-        ] = await uiConnection.remoteHandle().call("requestLoginAccess", this.pendingPermissions);
+        ] = await uiConnection.remoteHandle().call("requestLoginAccess", perms);
         seedFound = seedFoundResponse;
 
         // Save failed permissions.


### PR DESCRIPTION
Needed to do this for compatibility with Vuex, Vue's state manager. It creates proxy objects for items held in state, and when calling  through postMessage, permissions was passed as a Proxy object array with proxy object permission objects. I couldn't find a workaround, and there may be other instances in the library where this bug will show up.

Left the "hacky" comment since the TODO was right there and it can get revisited with a closer inspection of Vuex behavior.