### PR TITLE
[BREAKING] Breaking changes for metadata and download methods

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -41,12 +41,16 @@ export type CustomClientOptions = {
 /**
  * Config options for a single request.
  *
+ * @propety endpointPath - The endpoint to contact.
  * @property [data] - The data for a POST request.
  * @property [url] - The full url to contact. Will be computed from the portalUrl and endpointPath if not provided.
  * @property [method] - The request method.
  * @property [query] - Query parameters.
  * @property [timeout] - Request timeout. May be deprecated.
  * @property [extraPath] - An additional path to append to the URL, e.g. a 46-character skylink.
+ * @property [headers] - Any request headers to set.
+ * @property [transformRequest] - A function that allows manually transforming the request.
+ * @property [transformResponse] - A function that allows manually transforming the response.
  */
 export type RequestConfig = CustomClientOptions & {
   endpointPath: string;

--- a/src/client.ts
+++ b/src/client.ts
@@ -41,7 +41,7 @@ export type CustomClientOptions = {
 /**
  * Config options for a single request.
  *
- * @propety endpointPath - The endpoint to contact.
+ * @property endpointPath - The endpoint to contact.
  * @property [data] - The data for a POST request.
  * @property [url] - The full url to contact. Will be computed from the portalUrl and endpointPath if not provided.
  * @property [method] - The request method.

--- a/src/download.test.ts
+++ b/src/download.test.ts
@@ -160,17 +160,23 @@ describe("getMetadata", () => {
 
   const skynetFileMetadata = { filename: "sia.pdf" };
 
-  it.each(validSkylinkVariations)(
-    "should successfully fetch skynet file headers from skylink %s",
-    async (fullSkylink) => {
-      mock.onGet(skylinkUrl).replyOnce(200, skynetFileMetadata);
+  it("should successfully fetch skynet file metadata from skylink", async () => {
+    mock.onGet(skylinkUrl).replyOnce(200, skynetFileMetadata);
 
-      const { metadata } = await client.getMetadata(fullSkylink);
+    const { metadata } = await client.getMetadata(skylink);
 
-      expect(metadata).toEqual(skynetFileMetadata);
-    }
-  );
+    expect(metadata).toEqual(skynetFileMetadata);
+  });
 
+  it("should throw if a path is supplied", async () => {
+    mock.onGet(skylinkUrl).replyOnce(200, skynetFileMetadata);
+
+    await expect(client.getMetadata(`${skylink}/path/file`)).rejects.toThrowError(
+      "Skylink string should not contain a path"
+    );
+  });
+
+  // TODO: Add back in once the endpoint supports these headers.
   // it("should throw if no headers were returned", async () => {
   //   mock.onGet(skylinkUrl).replyOnce(200, {});
 

--- a/src/download.test.ts
+++ b/src/download.test.ts
@@ -3,14 +3,12 @@ import MockAdapter from "axios-mock-adapter";
 import { combineStrings, extractNonSkylinkPath } from "../utils/testing";
 
 import { SkynetClient, defaultSkynetPortalUrl, uriSkynetPrefix } from "./index";
-import { getSkylinkUrlForPortal } from "./download";
 
 const portalUrl = defaultSkynetPortalUrl;
 const hnsLink = "foo";
 const client = new SkynetClient(portalUrl);
 const skylink = "XABvi7JtJbQSMAcDwnUnmp2FKDPjg8_tTTFP4BwMSxVdEg";
 const skylinkBase32 = "bg06v2tidkir84hg0s1s4t97jaeoaa1jse1svrad657u070c9calq4g";
-const skylinkUrl = getSkylinkUrlForPortal(portalUrl, skylink);
 const sialink = `${uriSkynetPrefix}${skylink}`;
 
 const validSkylinkVariations = combineStrings(
@@ -86,12 +84,6 @@ describe("getHnsUrl", () => {
 
     expect(url).toEqual(`${expectedHnsUrl}${attachment}`);
   });
-
-  it("should return correctly formed hns URL with no-response-metadata set", async () => {
-    const url = await client.getHnsUrl(hnsLink, { noResponseMetadata: true });
-
-    expect(url).toEqual(`${expectedHnsUrl}?no-response-metadata=true`);
-  });
 });
 
 describe("getHnsresUrl", () => {
@@ -132,18 +124,6 @@ describe("getSkylinkUrl", () => {
     expect(url).toEqual(`${expectedUrl}/foo%3Fbar${attachment}`);
   });
 
-  it("should return correctly formed URLs with no-response-metadata set", async () => {
-    const url = await client.getSkylinkUrl(skylink, { noResponseMetadata: true });
-
-    expect(url).toEqual(`${expectedUrl}?no-response-metadata=true`);
-  });
-
-  it("should return correctly formed URLs with no-response-metadata set and with forced download", async () => {
-    const url = await client.getSkylinkUrl(skylink, { download: true, noResponseMetadata: true });
-
-    expect(url).toEqual(`${expectedUrl}?attachment=true&no-response-metadata=true`);
-  });
-
   const expectedBase32 = `https://${skylinkBase32}.siasky.net`;
 
   it.each(validSkylinkVariations)("should convert base64 skylink to base32 using skylink %s", async (fullSkylink) => {
@@ -171,19 +151,19 @@ describe("getSkylinkUrl", () => {
 describe("getMetadata", () => {
   let mock: MockAdapter;
 
+  const skylinkUrl = `${portalUrl}/skynet/metadata/${skylink}`;
+
   beforeEach(() => {
     mock = new MockAdapter(axios);
     mock.onHead(portalUrl).replyOnce(200, {}, { "skynet-portal-api": portalUrl });
   });
 
   const skynetFileMetadata = { filename: "sia.pdf" };
-  const headersFull = { "skynet-skylink": skylink, "skynet-file-metadata": JSON.stringify(skynetFileMetadata) };
 
   it.each(validSkylinkVariations)(
     "should successfully fetch skynet file headers from skylink %s",
     async (fullSkylink) => {
-      const skylinkUrl = await client.getSkylinkUrl(fullSkylink);
-      mock.onHead(skylinkUrl).replyOnce(200, {}, headersFull);
+      mock.onGet(skylinkUrl).replyOnce(200, skynetFileMetadata);
 
       const { metadata } = await client.getMetadata(fullSkylink);
 
@@ -191,25 +171,13 @@ describe("getMetadata", () => {
     }
   );
 
-  it.each(validSkylinkVariations)(
-    "should quietly return nothing when skynet metadata headers not present for skylink %s",
-    async (fullSkylink) => {
-      const skylinkUrl = await client.getSkylinkUrl(fullSkylink);
-      mock.onHead(skylinkUrl).replyOnce(200, {}, {});
+  // it("should throw if no headers were returned", async () => {
+  //   mock.onGet(skylinkUrl).replyOnce(200, {});
 
-      const { metadata } = await client.getMetadata(fullSkylink);
-
-      expect(metadata).toEqual({});
-    }
-  );
-
-  it("should throw if no headers were returned", async () => {
-    mock.onHead(skylinkUrl).replyOnce(200, {});
-
-    await expect(client.getMetadata(skylink)).rejects.toThrowError(
-      "Did not get 'headers' in response despite a successful request. Please try again and report this issue to the devs if it persists."
-    );
-  });
+  //   await expect(client.getMetadata(skylink)).rejects.toThrowError(
+  //     "Did not get 'headers' in response despite a successful request. Please try again and report this issue to the devs if it persists."
+  //   );
+  // });
 });
 
 describe("getFileContent", () => {
@@ -231,11 +199,10 @@ describe("getFileContent", () => {
     const skylinkUrl = await client.getSkylinkUrl(input);
     mock.onGet(skylinkUrl).replyOnce(200, skynetFileContents, fullHeaders);
 
-    const { data, contentType, metadata, skylink: skylink2 } = await client.getFileContent(input);
+    const { data, contentType, skylink: skylink2 } = await client.getFileContent(input);
 
     expect(data).toEqual(skynetFileContents);
     expect(contentType).toEqual("application/json");
-    expect(metadata).toEqual(skynetFileMetadata);
     expect(skylink2).toEqual(sialink);
   });
 
@@ -247,11 +214,10 @@ describe("getFileContent", () => {
       const skylinkUrl = await client.getSkylinkUrl(input);
       mock.onGet(skylinkUrl).replyOnce(200, skynetFileContents, headers);
 
-      const { data, contentType, metadata, skylink: skylink2 } = await client.getFileContent(input);
+      const { data, contentType, skylink: skylink2 } = await client.getFileContent(input);
 
       expect(data).toEqual(skynetFileContents);
       expect(contentType).toEqual("");
-      expect(metadata).toEqual({});
       expect(skylink2).toEqual("");
     }
   );

--- a/src/download.ts
+++ b/src/download.ts
@@ -556,7 +556,7 @@ function validateGetMetadataResponse(response: AxiosResponse): void {
     }
   } catch (err) {
     throw new Error(
-      `Did not get a complete resolve HNS response despite a successful request. Please try again and report this issue to the devs if it persists. Error: ${err}`
+      `Metadata response invalid despite a successful request. Please try again and report this issue to the devs if it persists. Error: ${err}`
     );
   }
 }

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -220,15 +220,18 @@ describe(`Integration test for portal ${portal}`, () => {
 
       // Get file content and check returned values.
 
-      const { data, contentType, metadata, portalUrl, skylink: returnedSkylink } = await client.getFileContent(skylink);
+      const { data, contentType, portalUrl, skylink: returnedSkylink } = await client.getFileContent(skylink);
       expect(data).toEqual(fileData);
       expect(contentType).toEqual("text/plain");
-      expect(metadata).toEqual(plaintextMetadata);
       expect(portalUrl).toEqualPortalUrl(portal);
       expect(skylink).toEqual(returnedSkylink);
     });
 
     it("Should get plaintext file metadata", async () => {
+      // TODO: Remove once the metadata changes are in prod.
+      const portal = "https://siasky.dev";
+      const client = new SkynetClient(portal);
+
       // Upload the data to acquire its skylink.
 
       const file = new File([fileData], dataKey, { type: plaintextType });
@@ -237,12 +240,13 @@ describe(`Integration test for portal ${portal}`, () => {
 
       // Get file metadata and check returned values.
 
-      const { contentType, metadata, portalUrl, skylink: returnedSkylink } = await client.getMetadata(skylink);
+      const { metadata } = await client.getMetadata(skylink);
 
-      expect(contentType).toEqual("text/plain");
       expect(metadata).toEqual(plaintextMetadata);
-      expect(portalUrl).toEqualPortalUrl(portal);
-      expect(skylink).toEqual(returnedSkylink);
+      // TODO: Add back in once the endpoint supports these headers.
+      // expect(contentType).toEqual("text/plain; charset=utf-8");
+      // expect(portalUrl).toEqualPortalUrl(portal);
+      // expect(skylink).toEqual(returnedSkylink);
     });
 
     it("Should get JSON file contents", async () => {


### PR DESCRIPTION
- [BREAKING] `getFileContent` and `getFileContentHns` no longer return metadata objects.
- [BREAKING] Remove `noResponseMetadata` custom option from download and HNS download methods.
- [BREAKING] `getMetadata` now takes a `CustomGetMetadataOptions` object for custom options.
- [BREAKING] Rename `resolveHns` option `endpointDownloadHnsres` to `endpointResolveHns`.