### PR TITLE
use skylink v2 format for registry entry

### DIFF
--- a/src/mysky/index.ts
+++ b/src/mysky/index.ts
@@ -34,6 +34,7 @@ import { popupCenter } from "./utils";
 import { validateObject, validateOptionalObject, validateString } from "../utils/validation";
 import { extractOptions } from "../utils/options";
 import { uriSkynetPrefix } from "../utils/url";
+import { base64RawUrlToUint8Array } from "../utils/encoding";
 
 export const mySkyDomain = "skynet-mysky.hns";
 export const mySkyDevDomain = "skynet-mysky-dev.hns";
@@ -344,10 +345,13 @@ export class MySky {
     const signedEntry = await this.connector.client.registry.getEntry(publicKey, dataKey, getEntryOpts);
     const revision = getRevisionFromSignedEntry(signedEntry);
 
+    // Add padding
+    const paddedDataLink = `${trimUriPrefix(dataLink, uriSkynetPrefix)}==`;
+
     // Build the registry entry.
     const entry: RegistryEntry = {
       dataKey,
-      data: stringToUint8ArrayUtf8(trimUriPrefix(dataLink, uriSkynetPrefix)),
+      data: base64RawUrlToUint8Array(paddedDataLink),
       revision,
     };
 


### PR DESCRIPTION
modifies mySky.setDataLink to use skylink v2 version of registry entry format. Could use helper method to reduce code repetition.