### PR TITLE
[BREAKING] Add trailing slash to URLs without path

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "skynet-mysky-utils": "^0.2.2",
     "tweetnacl": "^1.0.3",
     "url-join": "^4.0.1",
-    "url-parse": "^1.5.0"
+    "url-parse": "^1.5.1"
   },
   "devDependencies": {
     "@types/base64-js": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "skynet-mysky-utils": "^0.2.2",
     "tweetnacl": "^1.0.3",
     "url-join": "^4.0.1",
-    "url-parse": "1.4.7"
+    "url-parse": "^1.5.0"
   },
   "devDependencies": {
     "@types/base64-js": "^1.3.0",

--- a/src/download.test.ts
+++ b/src/download.test.ts
@@ -3,6 +3,7 @@ import MockAdapter from "axios-mock-adapter";
 import { combineStrings, extractNonSkylinkPath } from "../utils/testing";
 
 import { SkynetClient, defaultSkynetPortalUrl, uriSkynetPrefix } from "./index";
+import { trimForwardSlash } from "./utils/string";
 
 const portalUrl = defaultSkynetPortalUrl;
 const hnsLink = "foo";
@@ -41,12 +42,7 @@ describe("downloadFile", () => {
 
     const path = extractNonSkylinkPath(fullSkylink, skylink);
 
-    let fullExpectedUrl;
-    if (path !== "") {
-      fullExpectedUrl = `${expectedUrl}/${path}${attachment}`;
-    } else {
-      fullExpectedUrl = `${expectedUrl}${attachment}`;
-    }
+    let fullExpectedUrl = `${expectedUrl}${path}${attachment}`;
     // Change ?attachment=true to &attachment=true if need be.
     if ((fullExpectedUrl.match(/\?/g) || []).length > 1) {
       fullExpectedUrl = fullExpectedUrl.replace(attachment, "&attachment=true");
@@ -109,7 +105,7 @@ describe("getSkylinkUrl", () => {
 
       let expectedPathUrl = expectedUrl;
       if (path !== "") {
-        expectedPathUrl = `${expectedUrl}/${path}`;
+        expectedPathUrl = `${expectedUrl}${path}`;
       }
       expect(await client.getSkylinkUrl(fullSkylink)).toEqual(expectedPathUrl);
     }
@@ -135,7 +131,8 @@ describe("getSkylinkUrl", () => {
   const expectedBase32 = `https://${skylinkBase32}.siasky.net/`;
 
   it.each(validSkylinkVariations)("should convert base64 skylink to base32 using skylink %s", async (fullSkylink) => {
-    const path = extractNonSkylinkPath(fullSkylink, skylink);
+    let path = extractNonSkylinkPath(fullSkylink, skylink);
+    path = trimForwardSlash(path);
     const url = await client.getSkylinkUrl(fullSkylink, { subdomain: true });
 
     expect(url).toEqual(`${expectedBase32}${path}`);
@@ -284,10 +281,7 @@ describe("openFile", () => {
       const path = extractNonSkylinkPath(fullSkylink, skylink);
       await client.openFile(fullSkylink);
 
-      let expectedPathUrl = expectedUrl;
-      if (path !== "") {
-        expectedPathUrl = `${expectedUrl}/${path}`;
-      }
+      const expectedPathUrl = `${expectedUrl}${path}`;
       expect(windowOpen).toHaveBeenCalledTimes(1);
       expect(windowOpen).toHaveBeenCalledWith(expectedPathUrl, "_blank");
     }

--- a/src/download.test.ts
+++ b/src/download.test.ts
@@ -22,7 +22,7 @@ const validHnsLinkVariations = [hnsLink, `hns:${hnsLink}`, `hns://${hnsLink}`];
 
 const attachment = "?attachment=true";
 const expectedUrl = `${portalUrl}/${skylink}`;
-const expectedHnsUrl = `https://${hnsLink}.hns.siasky.net`;
+const expectedHnsUrl = `https://${hnsLink}.hns.siasky.net/`;
 const expectedHnsUrlNoSubdomain = `${portalUrl}/hns/${hnsLink}`;
 const expectedHnsresUrl = `${portalUrl}/hnsres/${hnsLink}`;
 
@@ -41,7 +41,12 @@ describe("downloadFile", () => {
 
     const path = extractNonSkylinkPath(fullSkylink, skylink);
 
-    let fullExpectedUrl = `${expectedUrl}${path}${attachment}`;
+    let fullExpectedUrl;
+    if (path !== "") {
+      fullExpectedUrl = `${expectedUrl}/${path}${attachment}`;
+    } else {
+      fullExpectedUrl = `${expectedUrl}${attachment}`;
+    }
     // Change ?attachment=true to &attachment=true if need be.
     if ((fullExpectedUrl.match(/\?/g) || []).length > 1) {
       fullExpectedUrl = fullExpectedUrl.replace(attachment, "&attachment=true");
@@ -102,7 +107,11 @@ describe("getSkylinkUrl", () => {
     async (fullSkylink) => {
       const path = extractNonSkylinkPath(fullSkylink, skylink);
 
-      expect(await client.getSkylinkUrl(fullSkylink)).toEqual(`${expectedUrl}${path}`);
+      let expectedPathUrl = expectedUrl;
+      if (path !== "") {
+        expectedPathUrl = `${expectedUrl}/${path}`;
+      }
+      expect(await client.getSkylinkUrl(fullSkylink)).toEqual(expectedPathUrl);
     }
   );
 
@@ -123,7 +132,7 @@ describe("getSkylinkUrl", () => {
     expect(url).toEqual(`${expectedUrl}/foo%3Fbar${attachment}`);
   });
 
-  const expectedBase32 = `https://${skylinkBase32}.siasky.net`;
+  const expectedBase32 = `https://${skylinkBase32}.siasky.net/`;
 
   it.each(validSkylinkVariations)("should convert base64 skylink to base32 using skylink %s", async (fullSkylink) => {
     const path = extractNonSkylinkPath(fullSkylink, skylink);
@@ -275,8 +284,12 @@ describe("openFile", () => {
       const path = extractNonSkylinkPath(fullSkylink, skylink);
       await client.openFile(fullSkylink);
 
+      let expectedPathUrl = expectedUrl;
+      if (path !== "") {
+        expectedPathUrl = `${expectedUrl}/${path}`;
+      }
       expect(windowOpen).toHaveBeenCalledTimes(1);
-      expect(windowOpen).toHaveBeenCalledWith(`${expectedUrl}${path}`, "_blank");
+      expect(windowOpen).toHaveBeenCalledWith(expectedPathUrl, "_blank");
     }
   );
 });

--- a/src/skylink/parse.test.ts
+++ b/src/skylink/parse.test.ts
@@ -18,7 +18,10 @@ describe("parseSkylink", () => {
 
     // Check that we extract the path correctly.
     const path = extractNonSkylinkPath(fullSkylink, skylink);
-    const fullPath = `${skylink}${path}`;
+    let fullPath = skylink;
+    if (path !== "") {
+      fullPath = `${skylink}/${path}`;
+    }
 
     expect(parseSkylink(fullSkylink, { includePath: true })).toEqual(fullPath);
     expect(parseSkylink(fullSkylink, { onlyPath: true })).toEqual(path);
@@ -38,8 +41,9 @@ describe("parseSkylink", () => {
     expect(parseSkylinkBase32(fullSkylink)).toEqual(skylinkBase32);
 
     // Test the fromSubdomain and onlyPath options together.
-    const path = extractNonSkylinkPath(fullSkylink, ""); // Don't need to remove the skylink from the path portion here.
-    expect(parseSkylink(fullSkylink, { fromSubdomain: true, onlyPath: true })).toEqual(path);
+    const expectedPath = extractNonSkylinkPath(fullSkylink, ""); // Don't need to remove the skylink from the path portion here.
+    const path = parseSkylink(fullSkylink, { fromSubdomain: true, onlyPath: true });
+    expect(path).toEqual(expectedPath);
   });
 
   it("should return null on invalid skylink", () => {

--- a/src/skylink/parse.test.ts
+++ b/src/skylink/parse.test.ts
@@ -18,10 +18,7 @@ describe("parseSkylink", () => {
 
     // Check that we extract the path correctly.
     const path = extractNonSkylinkPath(fullSkylink, skylink);
-    let fullPath = skylink;
-    if (path !== "") {
-      fullPath = `${skylink}/${path}`;
-    }
+    const fullPath = `${skylink}${path}`;
 
     expect(parseSkylink(fullSkylink, { includePath: true })).toEqual(fullPath);
     expect(parseSkylink(fullSkylink, { onlyPath: true })).toEqual(path);

--- a/src/skylink/parse.ts
+++ b/src/skylink/parse.ts
@@ -83,7 +83,7 @@ export function parseSkylink(skylinkUrl: string, customOptions?: ParseSkylinkOpt
   const path = matchPathname[SKYLINK_PATH_MATCH_POSITION];
 
   if (opts.includePath) return trimForwardSlash(skylinkAndPath);
-  else if (opts.onlyPath) return trimForwardSlash(path);
+  else if (opts.onlyPath) return path;
   else return matchPathname[SKYLINK_DIRECT_MATCH_POSITION];
 }
 
@@ -107,7 +107,7 @@ export function parseSkylinkBase32(skylinkUrl: string, customOptions?: ParseSkyl
   const matchHostname = parsed.hostname.match(SKYLINK_SUBDOMAIN_REGEX);
   if (matchHostname) {
     if (opts.onlyPath) {
-      return trimForwardSlash(trimSuffix(parsed.pathname, "/"));
+      return trimSuffix(parsed.pathname, "/");
     }
     return matchHostname[SKYLINK_DIRECT_MATCH_POSITION];
   }

--- a/src/skylink/parse.ts
+++ b/src/skylink/parse.ts
@@ -83,7 +83,7 @@ export function parseSkylink(skylinkUrl: string, customOptions?: ParseSkylinkOpt
   const path = matchPathname[SKYLINK_PATH_MATCH_POSITION];
 
   if (opts.includePath) return trimForwardSlash(skylinkAndPath);
-  else if (opts.onlyPath) return path;
+  else if (opts.onlyPath) return trimForwardSlash(path);
   else return matchPathname[SKYLINK_DIRECT_MATCH_POSITION];
 }
 
@@ -107,7 +107,7 @@ export function parseSkylinkBase32(skylinkUrl: string, customOptions?: ParseSkyl
   const matchHostname = parsed.hostname.match(SKYLINK_SUBDOMAIN_REGEX);
   if (matchHostname) {
     if (opts.onlyPath) {
-      return trimSuffix(parsed.pathname, "/");
+      return trimForwardSlash(trimSuffix(parsed.pathname, "/"));
     }
     return matchHostname[SKYLINK_DIRECT_MATCH_POSITION];
   }

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -7,17 +7,25 @@ const skylink = "XABvi7JtJbQSMAcDwnUnmp2FKDPjg8_tTTFP4BwMSxVdEg";
 const skylinkBase32 = "bg06v2tidkir84hg0s1s4t97jaeoaa1jse1svrad657u070c9calq4g";
 
 describe("addUrlQuery", () => {
-  it("Should return correctly formed URLs with query parameters", () => {
-    expect(addUrlQuery(portalUrl, { filename: "test" })).toEqual(`${portalUrl}?filename=test`);
-    expect(addUrlQuery(`${portalUrl}/path/`, { download: true })).toEqual(`${portalUrl}/path/?download=true`);
-    expect(addUrlQuery(`${portalUrl}/skynet/`, { foo: 1, bar: 2 })).toEqual(`${portalUrl}/skynet/?foo=1&bar=2`);
-    expect(addUrlQuery(`${portalUrl}/`, { attachment: true })).toEqual(`${portalUrl}/?attachment=true`);
-    expect(addUrlQuery(`${portalUrl}?foo=bar`, { attachment: true })).toEqual(`${portalUrl}?foo=bar&attachment=true`);
-    expect(addUrlQuery(`${portalUrl}/?attachment=true`, { foo: "bar" })).toEqual(
-      `${portalUrl}/?attachment=true&foo=bar`
-    );
-    expect(addUrlQuery(`${portalUrl}#foobar`, { foo: "bar" })).toEqual(`${portalUrl}?foo=bar#foobar`);
-  });
+  const parts: Array<[string, Record<string, unknown>, string]> = [
+    [portalUrl, { filename: "test" }, `${portalUrl}/?filename=test`],
+    [portalUrl, { attachment: true }, `${portalUrl}/?attachment=true`],
+    [`${portalUrl}/path`, { download: true }, `${portalUrl}/path?download=true`],
+    [`${portalUrl}/path/`, { download: true }, `${portalUrl}/path/?download=true`],
+    [`${portalUrl}/skynet/`, { foo: 1, bar: 2 }, `${portalUrl}/skynet/?foo=1&bar=2`],
+    [`${portalUrl}/`, { attachment: true }, `${portalUrl}/?attachment=true`],
+    [`${portalUrl}?foo=bar`, { attachment: true }, `${portalUrl}/?foo=bar&attachment=true`],
+    [`${portalUrl}/?attachment=true`, { foo: "bar" }, `${portalUrl}/?attachment=true&foo=bar`],
+    [`${portalUrl}#foobar`, { foo: "bar" }, `${portalUrl}/?foo=bar#foobar`],
+  ];
+
+  it.each(parts)(
+    "Should call addUrlQuery with URL %s and parameters %s and form URL %s",
+    (inputUrl, params, expectedUrl) => {
+      const url = addUrlQuery(inputUrl, params);
+      expect(url).toEqual(expectedUrl);
+    }
+  );
 });
 
 describe("getFullDomainUrlForPortal", () => {

--- a/utils/testing.ts
+++ b/utils/testing.ts
@@ -60,6 +60,10 @@ export async function compareFormData(formData: Record<string, unknown>, entries
  */
 export function extractNonSkylinkPath(url: string, skylink: string): string {
   const parsed = parse(url, {});
-  const path = parsed.pathname.replace(skylink, ""); // Remove skylink to get the path.
-  return trimForwardSlash(path);
+  let path = parsed.pathname.replace(skylink, ""); // Remove skylink to get the path.
+  path = trimForwardSlash(path);
+  if (path != "") {
+    path = `/${path}`;
+  }
+  return path;
 }

--- a/utils/testing.ts
+++ b/utils/testing.ts
@@ -61,8 +61,10 @@ export async function compareFormData(formData: Record<string, unknown>, entries
 export function extractNonSkylinkPath(url: string, skylink: string): string {
   const parsed = parse(url, {});
   let path = parsed.pathname.replace(skylink, ""); // Remove skylink to get the path.
+  // Ensure there is only one leading slash.
   path = trimForwardSlash(path);
-  if (path != "") {
+  // Don't add back the slash if there is no path.
+  if (path !== "") {
     path = `/${path}`;
   }
   return path;

--- a/utils/testing.ts
+++ b/utils/testing.ts
@@ -60,10 +60,6 @@ export async function compareFormData(formData: Record<string, unknown>, entries
  */
 export function extractNonSkylinkPath(url: string, skylink: string): string {
   const parsed = parse(url, {});
-  let path = parsed.pathname.replace(skylink, ""); // Remove skylink to get the path.
-  path = trimForwardSlash(path);
-  if (path != "") {
-    path = `/${path}`;
-  }
-  return path;
+  const path = parsed.pathname.replace(skylink, ""); // Remove skylink to get the path.
+  return trimForwardSlash(path);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4508,7 +4508,7 @@ url-join@^4.0.1:
   resolved "https://registry.yarnpkg.com/url-join/-/url-join-4.0.1.tgz#b642e21a2646808ffa178c4c5fda39844e12cde7"
   integrity sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==
 
-url-parse@^1.5.0:
+url-parse@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.1.tgz#d5fa9890af8a5e1f274a2c98376510f6425f6e3b"
   integrity sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -745,14 +745,6 @@
     "@typescript-eslint/typescript-estree" "4.24.0"
     debug "^4.1.1"
 
-"@typescript-eslint/scope-manager@4.23.0":
-  version "4.23.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.23.0.tgz#8792ef7eacac122e2ec8fa2d30a59b8d9a1f1ce4"
-  integrity sha512-ZZ21PCFxPhI3n0wuqEJK9omkw51wi2bmeKJvlRZPH5YFkcawKOuRMQMnI8mH6Vo0/DoHSeZJnHiIx84LmVQY+w==
-  dependencies:
-    "@typescript-eslint/types" "4.23.0"
-    "@typescript-eslint/visitor-keys" "4.23.0"
-
 "@typescript-eslint/scope-manager@4.24.0":
   version "4.24.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.24.0.tgz#38088216f0eaf235fa30ed8cabf6948ec734f359"
@@ -761,28 +753,10 @@
     "@typescript-eslint/types" "4.24.0"
     "@typescript-eslint/visitor-keys" "4.24.0"
 
-"@typescript-eslint/types@4.23.0":
-  version "4.23.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.23.0.tgz#da1654c8a5332f4d1645b2d9a1c64193cae3aa3b"
-  integrity sha512-oqkNWyG2SLS7uTWLZf6Sr7Dm02gA5yxiz1RP87tvsmDsguVATdpVguHr4HoGOcFOpCvx9vtCSCyQUGfzq28YCw==
-
 "@typescript-eslint/types@4.24.0":
   version "4.24.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.24.0.tgz#6d0cca2048cbda4e265e0c4db9c2a62aaad8228c"
   integrity sha512-tkZUBgDQKdvfs8L47LaqxojKDE+mIUmOzdz7r+u+U54l3GDkTpEbQ1Jp3cNqqAU9vMUCBA1fitsIhm7yN0vx9Q==
-
-"@typescript-eslint/typescript-estree@4.23.0":
-  version "4.23.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.23.0.tgz#0753b292097523852428a6f5a1aa8ccc1aae6cd9"
-  integrity sha512-5Sty6zPEVZF5fbvrZczfmLCOcby3sfrSPu30qKoY1U3mca5/jvU5cwsPb/CO6Q3ByRjixTMIVsDkqwIxCf/dMw==
-  dependencies:
-    "@typescript-eslint/types" "4.23.0"
-    "@typescript-eslint/visitor-keys" "4.23.0"
-    debug "^4.1.1"
-    globby "^11.0.1"
-    is-glob "^4.0.1"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
 
 "@typescript-eslint/typescript-estree@4.24.0":
   version "4.24.0"
@@ -796,14 +770,6 @@
     is-glob "^4.0.1"
     semver "^7.3.2"
     tsutils "^3.17.1"
-
-"@typescript-eslint/visitor-keys@4.23.0":
-  version "4.23.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.23.0.tgz#7215cc977bd3b4ef22467b9023594e32f9e4e455"
-  integrity sha512-5PNe5cmX9pSifit0H+nPoQBXdbNzi5tOEec+3riK+ku4e3er37pKxMKDH5Ct5Y4fhWxcD4spnlYjxi9vXbSpwg==
-  dependencies:
-    "@typescript-eslint/types" "4.23.0"
-    eslint-visitor-keys "^2.0.0"
 
 "@typescript-eslint/visitor-keys@4.24.0":
   version "4.24.0"
@@ -4542,10 +4508,10 @@ url-join@^4.0.1:
   resolved "https://registry.yarnpkg.com/url-join/-/url-join-4.0.1.tgz#b642e21a2646808ffa178c4c5fda39844e12cde7"
   integrity sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==
 
-url-parse@1.4.7:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.7.tgz#a8a83535e8c00a316e403a5db4ac1b9b853ae278"
-  integrity sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==
+url-parse@^1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.1.tgz#d5fa9890af8a5e1f274a2c98376510f6425f6e3b"
+  integrity sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"


### PR DESCRIPTION
Fixes CVE concerning `url-parse` and brings `skynet-js` more in line with the standards for URL handling.