### PR TITLE
Fix mySky.setEntryData

### DIFF
--- a/src/mysky/index.ts
+++ b/src/mysky/index.ts
@@ -423,7 +423,7 @@ export class MySky {
    * @param [customOptions] - Additional settings that can optionally be set.
    * @returns - The entry data.
    */
-  async getEntryData(path: string, customOptions: CustomGetEntryOptions): Promise<EntryData> {
+  async getEntryData(path: string, customOptions?: CustomGetEntryOptions): Promise<EntryData> {
     validateString("path", path, "parameter");
     validateOptionalObject("customOptions", customOptions, "parameter", defaultGetEntryOptions);
 
@@ -453,7 +453,7 @@ export class MySky {
    * @returns - The entry data.
    * @throws - Will throw if the length of the data is > 70 bytes.
    */
-  async setEntryData(path: string, data: Uint8Array, customOptions: CustomSetEntryOptions): Promise<EntryData> {
+  async setEntryData(path: string, data: Uint8Array, customOptions?: CustomSetJSONOptions): Promise<EntryData> {
     validateString("path", path, "parameter");
     validateUint8Array("data", data, "parameter");
     validateOptionalObject("customOptions", customOptions, "parameter", defaultGetEntryOptions);
@@ -468,7 +468,7 @@ export class MySky {
     }
 
     const opts = {
-      ...defaultSetEntryOptions,
+      ...defaultSetJSONOptions,
       ...this.connector.client.customOptions,
       ...customOptions,
     };

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -21,13 +21,19 @@ export const defaultBaseOptions = {
  * @param opts - The given options.
  * @param model - The model options.
  * @returns - The extracted custom options.
+ * @throws - If the given opts don't contain all properties of the model.
  */
 export function extractOptions<T extends Record<string, unknown>>(opts: Record<string, unknown>, model: T): T {
   const result: Record<string, unknown> = {};
   for (const property in model) {
-    if (Object.prototype.hasOwnProperty.call(model, property)) {
-      result[property] = opts[property];
+    if (!Object.prototype.hasOwnProperty.call(model, property)) {
+      continue;
     }
+    // Throw if the given options don't contain the model's property.
+    if (!Object.prototype.hasOwnProperty.call(opts, property)) {
+      throw new Error(`Property '${property}' not found`);
+    }
+    result[property] = opts[property];
   }
 
   return result as T;

--- a/src/utils/validation.test.ts
+++ b/src/utils/validation.test.ts
@@ -2,6 +2,7 @@ import {
   validateBigint,
   validateNumber,
   validateObject,
+  validateString,
   validateUint8Array,
   validateUint8ArrayLen,
 } from "./validation";
@@ -26,6 +27,14 @@ describe("validateObject", () => {
   it("validateObject should catch null input", () => {
     expect(() => validateObject("test", null, "parameter")).toThrowError(
       "Expected parameter 'test' to be non-null, was 'null'"
+    );
+  });
+});
+
+describe("validateString", () => {
+  it("validateString should catch undefined input", () => {
+    expect(() => validateString("test", undefined, "parameter")).toThrowError(
+      "Expected parameter 'test' to be type 'string', was 'undefined'"
     );
   });
 });


### PR DESCRIPTION
NOTE: This is a temporary fix, as the SkyDB caching will remove the need for the
setEntryData options to contain getEntry options, and we can change the option
type from CustomSetJSONOptions to CustomSetEntryOptions at that time.