### PR TITLE
Resolve some nits

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -82,8 +82,8 @@ export class SkynetClient {
   protected initialPortalUrl: string;
   // The resolved API portal URL. The request won't be made until needed, or `initPortalUrl()` is called. The request is only made once, for all Skynet Clients.
   protected static resolvedPortalUrl?: Promise<string>;
-  // The given portal URL, if one was passed in to `new SkynetClient()`.
-  protected givenPortalUrl?: string;
+  // The custom portal URL, if one was passed in to `new SkynetClient()`.
+  protected customPortalUrl?: string;
 
   // Set methods (defined in other files).
 
@@ -159,7 +159,7 @@ export class SkynetClient {
       initialPortalUrl = defaultPortalUrl();
     } else {
       // Portal was given, don't make the request for the resolved portal URL.
-      this.givenPortalUrl = initialPortalUrl;
+      this.customPortalUrl = initialPortalUrl;
     }
     this.initialPortalUrl = initialPortalUrl;
     this.customOptions = customOptions;
@@ -172,6 +172,11 @@ export class SkynetClient {
    */
   /* istanbul ignore next */
   async initPortalUrl(): Promise<void> {
+    if (this.customPortalUrl) {
+      // Tried to make a request for the API portal URL when a custom URL was already provided.
+      return;
+    }
+
     if (!SkynetClient.resolvedPortalUrl) {
       SkynetClient.resolvedPortalUrl = new Promise((resolve, reject) => {
         this.executeRequest({
@@ -207,8 +212,8 @@ export class SkynetClient {
    */
   /* istanbul ignore next */
   async portalUrl(): Promise<string> {
-    if (this.givenPortalUrl) {
-      return this.givenPortalUrl;
+    if (this.customPortalUrl) {
+      return this.customPortalUrl;
     }
 
     // Make the request if needed and not done so.

--- a/src/download.ts
+++ b/src/download.ts
@@ -235,6 +235,8 @@ export function getSkylinkUrlForPortal(
 
   let url;
   if (opts.subdomain) {
+    // The caller wants to use a URL with the skylink as a base32 subdomain.
+    //
     // Get the path from the skylink. Use the empty string if not found.
     const skylinkPath = parseSkylink(skylinkUrl, { onlyPath: true }) ?? "";
     // Get just the skylink.
@@ -256,6 +258,7 @@ export function getSkylinkUrlForPortal(
     url = makeUrl(portalUrl, opts.endpointDownload, skylink);
     url = makeUrl(url, path);
   }
+
   return addUrlQuery(url, query);
 }
 

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -48,6 +48,18 @@ expect.extend({
 });
 
 describe(`Integration test for portal ${portal}`, () => {
+  describe("initPortalUrl", () => {
+    it("Calling initPortalUrl after providing a custom portal URL should have no effect", async () => {
+      const portalUrl1 = await client.portalUrl();
+      expect(portalUrl1).toEqual(portal);
+
+      await client.initPortalUrl();
+
+      const portalUrl2 = await client.portalUrl();
+      expect(portalUrl2).toEqual(portal);
+    });
+  });
+
   describe("File API integration tests", () => {
     const userID = "89e5147864297b80f5ddf29711ba8c093e724213b0dcbefbc3860cc6d598cc35";
     const path = "snew.hns/asdf";
@@ -327,52 +339,27 @@ describe(`Integration test for portal ${portal}`, () => {
       },
     };
 
-    // TODO: This test is broken in Node.
-    // it("Should upload and download directories", async () => {
-    //   const directory = {
-    //     "i-am-not/file1.jpeg": new File(["foo1"], "i-am-not/file1.jpeg"),
-    //     "i-am-not/file2.jpeg": new File(["foo2"], "i-am-not/file2.jpeg"),
-    //     "i-am-not/me-neither/file3.jpeg": new File(["foo3"], "i-am-not/me-neither/file3.jpeg"),
-    //   };
-    //   const dirMetadata = {
-    //     filename: "dirname",
-    //     length: 12,
-    //     subfiles: {
-    //       "i-am-not:file1.jpeg": {
-    //         contenttype: "image/jpeg",
-    //         filename: "i-am-not:file1.jpeg",
-    //         len: 4,
-    //       },
-    //       "i-am-not:file2.jpeg": {
-    //         contenttype: "image/jpeg",
-    //         filename: "i-am-not:file2.jpeg",
-    //         len: 4,
-    //         offset: 4,
-    //       },
-    //       "i-am-not:me-neither:file3.jpeg": {
-    //         contenttype: "image/jpeg",
-    //         filename: "i-am-not:me-neither:file3.jpeg",
-    //         len: 4,
-    //         offset: 8,
-    //       },
-    //     },
-    //   };
-    //   const dirname = "dirname";
-    //   const dirType = "application/zip";
+    it("Should upload and download directories", async () => {
+      const directory = {
+        "i-am-not/file1.jpeg": new File(["foo1"], "i-am-not/file1.jpeg"),
+        "i-am-not/file2.jpeg": new File(["foo2"], "i-am-not/file2.jpeg"),
+        "i-am-not/me-neither/file3.jpeg": new File(["foo3"], "i-am-not/me-neither/file3.jpeg"),
+      };
+      const dirname = "dirname";
+      const dirType = "application/zip";
 
-    //   const { skylink } = await client.uploadDirectory(directory, dirname);
-    //   expect(skylink).not.toEqual("");
+      const { skylink } = await client.uploadDirectory(directory, dirname);
+      expect(skylink).not.toEqual("");
 
-    //   // Get file content and check returned values.
+      // Get file content and check returned values.
 
-    //   const resp = await client.getFileContent(skylink);
-    //   const { data, contentType, metadata, portalUrl, skylink: returnedSkylink } = resp;
-    //   expect(data).toEqual(expect.any(String));
-    //   expect(contentType).toEqual(dirType);
-    //   expect(metadata).toEqual(dirMetadata);
-    //   expect(portalUrl).toEqualPortalUrl(portal);
-    //   expect(skylink).toEqual(returnedSkylink);
-    // });
+      const resp = await client.getFileContent(skylink);
+      const { data, contentType, portalUrl, skylink: returnedSkylink } = resp;
+      expect(data).toEqual(expect.any(String));
+      expect(contentType).toEqual(dirType);
+      expect(portalUrl).toEqualPortalUrl(portal);
+      expect(skylink).toEqual(returnedSkylink);
+    });
 
     it("Custom filenames should take effect", async () => {
       const customFilename = "asdf!!";

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -3,6 +3,20 @@ import { Buffer } from "buffer";
 import { throwValidationError, validateHexString, validateString } from "./validation";
 
 /**
+ * Prepends the prefix to the given string only if the string does not already start with the prefix.
+ *
+ * @param str - The string.
+ * @param prefix - The prefix.
+ * @returns - The prefixed string.
+ */
+export function ensurePrefix(str: string, prefix: string): string {
+  if (!str.startsWith(prefix)) {
+    str = `${prefix}${str}`;
+  }
+  return str;
+}
+
+/**
  * Removes slashes from the beginning and end of the string.
  *
  * @param str - The string to process.


### PR DESCRIPTION
Resolves some minor nits:

- Avoid unnecessary reassigning of `publicKey` variable. Closes #25 
- Explain `if (opts.subdomain)` conditional in a comment. Closes #26 
- Address followups from "Add async portal url init..." PR. Closes #33  
- Add back "Should upload and download directories" integration test. Closes #64