### PR TITLE
Revert "Bump husky from 6.0.0 to 7.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "axios-mock-adapter": "^1.18.2",
     "eslint": "^7.11.0",
     "eslint-plugin-jsdoc": "^35.0.0",
-    "husky": "^7.0.0",
+    "husky": "^6.0.0",
     "jest": "^26.6.3",
     "lint-staged": "^11.0.0",
     "prettier": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2288,10 +2288,10 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
-husky@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-7.0.0.tgz#3dbd5d28e76234689ee29bb41e048f28e3e46616"
-  integrity sha512-xK7lO0EtSzfFPiw+oQncQVy/XqV7UVVjxBByc+Iv5iK3yhW9boDoWgvZy3OGo48QKg/hUtZkzz0hi2HXa0kn7w==
+husky@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-6.0.0.tgz#810f11869adf51604c32ea577edbc377d7f9319e"
+  integrity sha512-SQS2gDTB7tBN486QSoKPKQItZw97BMOd+Kdb6ghfpBc0yXyzrddI0oDV5MkDAbuB4X2mO3/nj60TRMcYxwzZeQ==
 
 iconv-lite@0.4.24:
   version "0.4.24"


### PR DESCRIPTION
Reverts SkynetLabs/skynet-js#192

Husky bump causing potential issues when installing, please revisit and bump if this is not an issue.

```
yarn install v1.22.5
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@2.3.2: The platform "linux" is incompatible with this module.
info "fsevents@2.3.2" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
$ husky install
husky - Git hooks failed to install
spawnSync git ENOENT
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```