### PR TITLE
Improve tus error

### DIFF
--- a/src/upload.ts
+++ b/src/upload.ts
@@ -241,7 +241,10 @@ export async function uploadLargeFileRequest(
         xhr.withCredentials = true;
       },
       onError: (error: Error) => {
-        reject(error);
+        // @ts-expect-error tus-client-js Error is not typed correctly.
+        const res = error.originalResponse;
+        const message = res ? res.getBody() || error : error;
+        reject(new Error(message.trim()));
       },
       onSuccess: async () => {
         if (!upload.url) {


### PR DESCRIPTION
Previously the error returned from tus by skynet-js was too long and technical.
Now we will return the most salient information.

Before:

```
Error: tus: unexpected response while creating upload, originated from request (method: POST, url: https://siasky.xyz/skynet/tus, response code: 413, response text: upload exceeds maximum size: 3580710912 > 1073741824
, request id: n/a)
```

After:

```
Error: upload exceeds maximum size: 26628423680 > 1073741824
```