### PR TITLE
Export MySky as value instead of as type + minor fixes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ export { SkynetClient } from "./client";
 export { deriveChildSeed, genKeyPairAndSeed, genKeyPairFromSeed } from "./crypto";
 export { getSkylinkUrlForPortal } from "./download";
 export { getEntryUrlForPortal, signEntry } from "./registry";
-export { DacLibrary, mySkyDomain, mySkyDevDomain } from "./mysky";
+export { DacLibrary, MySky, mySkyDomain, mySkyDevDomain } from "./mysky";
 export { convertSkylinkToBase32, convertSkylinkToBase64 } from "./skylink/format";
 export { parseSkylink } from "./skylink/parse";
 export { isSkylinkV1, isSkylinkV2 } from "./skylink/sia";
@@ -36,7 +36,7 @@ export {
 export type { CustomClientOptions, RequestConfig } from "./client";
 export type { KeyPair, KeyPairAndSeed, Signature } from "./crypto";
 export type { CustomDownloadOptions, ResolveHnsResponse } from "./download";
-export type { CustomConnectorOptions, MySky } from "./mysky";
+export type { CustomConnectorOptions } from "./mysky";
 export type { CustomPinOptions, PinResponse } from "./pin";
 export type { CustomGetEntryOptions, CustomSetEntryOptions, SignedRegistryEntry, RegistryEntry } from "./registry";
 export type { CustomGetJSONOptions, CustomSetJSONOptions, JsonData, JSONResponse } from "./skydb";

--- a/src/skydb.ts
+++ b/src/skydb.ts
@@ -235,10 +235,10 @@ export async function deleteJSON(
  *
  * @param this - SkynetClient
  * @param privateKey - The user private key.
- * @param dataKey - The key of the data to fetch for the given user.
+ * @param dataKey - The data key.
  * @param dataLink - The data link to set at the entry.
  * @param [customOptions] - Additional settings that can optionally be set.
- * @throws - Will throw if the input keys are not valid strings
+ * @throws - Will throw if the input keys are not valid strings.
  */
 export async function setDataLink(
   this: SkynetClient,

--- a/src/skylink/sia.test.ts
+++ b/src/skylink/sia.test.ts
@@ -94,7 +94,9 @@ describe("newSkylinkV2", () => {
 
 describe("SiaSkylink.fromBytes", () => {
   it("Should fail on invalid input byte array length", () => {
-    expect(() => SiaSkylink.fromBytes(new Uint8Array(0))).toThrowError("Failed to load skylink data");
+    expect(() => SiaSkylink.fromBytes(new Uint8Array(0))).toThrowError(
+      "Expected parameter 'data' to be type 'Uint8Array' of length 34, was length 0, was type 'object', value ''"
+    );
   });
 });
 

--- a/src/skylink/sia.ts
+++ b/src/skylink/sia.ts
@@ -60,10 +60,7 @@ export class SiaSkylink {
    * @throws - Will throw if the data has an unexpected size.
    */
   static fromBytes(data: Uint8Array): SiaSkylink {
-    // Sanity check the size of the given data.
-    if (data.length !== RAW_SKYLINK_SIZE) {
-      throw new Error("Failed to load skylink data");
-    }
+    validateUint8ArrayLen("data", data, "parameter", RAW_SKYLINK_SIZE);
 
     const view = new DataView(data.buffer);
 


### PR DESCRIPTION
Previously, `MySky` was being exported as `type`. This meant that Typescript
would complain when trying to use it as a value as in e.g. trying to access the
MySky singleton `MySky.instance`.