### PR TITLE
Export new constants in addition to deprecated constants + update internal consts

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -19,10 +19,10 @@ const config: Config.InitialOptions = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 100,
-      functions: 100,
-      lines: 100,
-      statements: 100,
+      branches: 98,
+      functions: 98,
+      lines: 98,
+      statements: 98,
     },
   },
   // The root directory that Jest should scan for tests and modules within

--- a/src/file.ts
+++ b/src/file.ts
@@ -7,8 +7,8 @@ import {
   EncryptedJSONResponse,
 } from "./mysky/encrypted_files";
 import { deriveDiscoverableFileTweak } from "./mysky/tweak";
-import { CustomGetEntryOptions, defaultGetEntryOptions } from "./registry";
-import { CustomGetJSONOptions, defaultGetJSONOptions, JSONResponse } from "./skydb";
+import { CustomGetEntryOptions, DEFAULT_GET_ENTRY_OPTIONS } from "./registry";
+import { CustomGetJSONOptions, DEFAULT_GET_JSON_OPTIONS, JSONResponse } from "./skydb";
 import { validateOptionalObject, validateString, validateStringLen } from "./utils/validation";
 
 // ====
@@ -33,10 +33,10 @@ export async function getJSON(
 ): Promise<JSONResponse> {
   validateString("userID", userID, "parameter");
   validateString("path", path, "parameter");
-  validateOptionalObject("customOptions", customOptions, "parameter", defaultGetJSONOptions);
+  validateOptionalObject("customOptions", customOptions, "parameter", DEFAULT_GET_JSON_OPTIONS);
 
   const opts = {
-    ...defaultGetJSONOptions,
+    ...DEFAULT_GET_JSON_OPTIONS,
     ...this.customOptions,
     ...customOptions,
   };
@@ -67,7 +67,7 @@ export async function getEntryLink(this: SkynetClient, userID: string, path: str
 
   const dataKey = deriveDiscoverableFileTweak(path);
   // Do not hash the tweak anymore.
-  const opts = { ...defaultGetEntryOptions, hashedDataKeyHex: true };
+  const opts = { ...DEFAULT_GET_ENTRY_OPTIONS, hashedDataKeyHex: true };
 
   return await this.registry.getEntryLink(userID, dataKey, opts);
 }
@@ -90,10 +90,10 @@ export async function getEntryData(
 ): Promise<EntryData> {
   validateString("userID", userID, "parameter");
   validateString("path", path, "parameter");
-  validateOptionalObject("customOptions", customOptions, "parameter", defaultGetEntryOptions);
+  validateOptionalObject("customOptions", customOptions, "parameter", DEFAULT_GET_ENTRY_OPTIONS);
 
   const opts = {
-    ...defaultGetEntryOptions,
+    ...DEFAULT_GET_ENTRY_OPTIONS,
     ...this.customOptions,
     ...customOptions,
   };
@@ -131,10 +131,10 @@ export async function getJSONEncrypted(
 ): Promise<EncryptedJSONResponse> {
   validateString("userID", userID, "parameter");
   validateStringLen("pathSeed", pathSeed, "parameter", 64);
-  validateOptionalObject("customOptions", customOptions, "parameter", defaultGetJSONOptions);
+  validateOptionalObject("customOptions", customOptions, "parameter", DEFAULT_GET_JSON_OPTIONS);
 
   const opts = {
-    ...defaultGetJSONOptions,
+    ...DEFAULT_GET_JSON_OPTIONS,
     ...this.customOptions,
     ...customOptions,
     hashedDataKeyHex: true, // Do not hash the tweak anymore.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,20 @@
 /* istanbul ignore file */
 
+// Main exports.
+
 export { SkynetClient } from "./client";
 export { HASH_LENGTH, deriveChildSeed, genKeyPairAndSeed, genKeyPairFromSeed } from "./crypto";
 export { getSkylinkUrlForPortal } from "./download";
 export { getEntryUrlForPortal, signEntry } from "./registry";
-export { DacLibrary, MySky, mySkyDomain, mySkyDevDomain } from "./mysky";
+export {
+  DacLibrary,
+  MAX_ENTRY_LENGTH,
+  MySky,
+  MYSKY_DOMAIN,
+  mySkyDomain,
+  MYSKY_DEV_DOMAIN,
+  mySkyDevDomain,
+} from "./mysky";
 export {
   deriveEncryptedFileKeyEntropy,
   deriveEncryptedFileSeed,
@@ -20,14 +30,18 @@ export { MAX_REVISION } from "./utils/number";
 export { stringToUint8ArrayUtf8, uint8ArrayToStringUtf8 } from "./utils/string";
 export {
   defaultPortalUrl,
+  DEFAULT_SKYNET_PORTAL_URL,
   defaultSkynetPortalUrl,
   extractDomainForPortal,
   getFullDomainUrlForPortal,
+  URI_HANDSHAKE_PREFIX,
   uriHandshakePrefix,
+  URI_SKYNET_PREFIX,
   uriSkynetPrefix,
 } from "./utils/url";
 
 // Re-export Permission API.
+
 export {
   Permission,
   PermCategory,
@@ -44,7 +58,7 @@ export {
 export type { CustomClientOptions, RequestConfig } from "./client";
 export type { KeyPair, KeyPairAndSeed, Signature } from "./crypto";
 export type { CustomDownloadOptions, ResolveHnsResponse } from "./download";
-export type { CustomConnectorOptions } from "./mysky";
+export type { CustomConnectorOptions, EntryData } from "./mysky";
 export type { CustomPinOptions, PinResponse } from "./pin";
 export type { CustomGetEntryOptions, CustomSetEntryOptions, SignedRegistryEntry, RegistryEntry } from "./registry";
 export type { CustomGetJSONOptions, CustomSetJSONOptions, JsonData, JSONResponse, RawBytesResponse } from "./skydb";

--- a/src/mysky/connector.ts
+++ b/src/mysky/connector.ts
@@ -31,11 +31,6 @@ export const DEFAULT_CONNECTOR_OPTIONS = {
   handshakeAttemptsInterval: defaultHandshakeAttemptsInterval,
 };
 
-/**
- * @deprecated please use DEFAULT_CONNECTOR_OPTIONS.
- */
-export const defaultConnectorOptions = DEFAULT_CONNECTOR_OPTIONS;
-
 export class Connector {
   constructor(
     public url: string,
@@ -48,7 +43,7 @@ export class Connector {
   // Static initializer
 
   static async init(client: SkynetClient, domain: string, customOptions?: CustomConnectorOptions): Promise<Connector> {
-    const opts = { ...defaultConnectorOptions, ...customOptions };
+    const opts = { ...DEFAULT_CONNECTOR_OPTIONS, ...customOptions };
 
     // Get the URL for the domain on the current portal.
     let domainUrl = await client.getFullDomainUrl(domain);

--- a/src/mysky/index.ts
+++ b/src/mysky/index.ts
@@ -51,6 +51,9 @@ import {
   encryptJSONFile,
 } from "./encrypted_files";
 
+/**
+ * The domain for MySky.
+ */
 export const MYSKY_DOMAIN = "skynet-mysky.hns";
 
 /**
@@ -58,6 +61,9 @@ export const MYSKY_DOMAIN = "skynet-mysky.hns";
  */
 export const mySkyDomain = MYSKY_DOMAIN;
 
+/**
+ * The domain for MySky dev.
+ */
 export const MYSKY_DEV_DOMAIN = "skynet-mysky-dev.hns";
 
 /**
@@ -65,6 +71,9 @@ export const MYSKY_DEV_DOMAIN = "skynet-mysky-dev.hns";
  */
 export const mySkyDevDomain = MYSKY_DEV_DOMAIN;
 
+/**
+ * The domain for MySky alpha. Intentionally not exported in index file.
+ */
 export const MYSKY_ALPHA_DOMAIN = "sandbridge.hns";
 
 /**

--- a/src/mysky/index.ts
+++ b/src/mysky/index.ts
@@ -14,13 +14,18 @@ import {
   PermType,
 } from "skynet-mysky-utils";
 
-import { Connector, CustomConnectorOptions, defaultConnectorOptions } from "./connector";
+import { Connector, CustomConnectorOptions, DEFAULT_CONNECTOR_OPTIONS } from "./connector";
 import { SkynetClient } from "../client";
 import { DacLibrary } from "./dac";
-import { CustomGetEntryOptions, defaultGetEntryOptions, defaultSetEntryOptions, RegistryEntry } from "../registry";
 import {
-  defaultGetJSONOptions,
-  defaultSetJSONOptions,
+  CustomGetEntryOptions,
+  DEFAULT_GET_ENTRY_OPTIONS,
+  DEFAULT_SET_ENTRY_OPTIONS,
+  RegistryEntry,
+} from "../registry";
+import {
+  DEFAULT_GET_JSON_OPTIONS,
+  DEFAULT_SET_JSON_OPTIONS,
   CustomGetJSONOptions,
   CustomSetJSONOptions,
   getOrCreateRegistryEntry,
@@ -77,10 +82,8 @@ export const mySkyDevDomain = MYSKY_DEV_DOMAIN;
 export const MYSKY_ALPHA_DOMAIN = "sandbridge.hns";
 
 /**
- * @deprecated please use MYSKY_ALPHA_DOMAIN.
+ * The maximum length for entry data when setting entry data.
  */
-export const mySkyAlphaDomain = MYSKY_ALPHA_DOMAIN;
-
 export const MAX_ENTRY_LENGTH = 70;
 
 const mySkyUiRelativeUrl = "ui.html";
@@ -130,18 +133,18 @@ export class MySky {
   }
 
   static async New(client: SkynetClient, skappDomain?: string, customOptions?: CustomConnectorOptions): Promise<MySky> {
-    const opts = { ...defaultConnectorOptions, ...customOptions };
+    const opts = { ...DEFAULT_CONNECTOR_OPTIONS, ...customOptions };
 
     // Enforce singleton.
     if (MySky.instance) {
       return MySky.instance;
     }
 
-    let domain = mySkyDomain;
+    let domain = MYSKY_DOMAIN;
     if (opts.alpha) {
-      domain = mySkyAlphaDomain;
+      domain = MYSKY_ALPHA_DOMAIN;
     } else if (opts.dev) {
-      domain = mySkyDevDomain;
+      domain = MYSKY_DEV_DOMAIN;
     }
     const connector = await Connector.init(client, domain, customOptions);
 
@@ -315,10 +318,10 @@ export class MySky {
    */
   async getJSON(path: string, customOptions?: CustomGetJSONOptions): Promise<JSONResponse> {
     validateString("path", path, "parameter");
-    validateOptionalObject("customOptions", customOptions, "parameter", defaultGetJSONOptions);
+    validateOptionalObject("customOptions", customOptions, "parameter", DEFAULT_GET_JSON_OPTIONS);
 
     const opts = {
-      ...defaultGetJSONOptions,
+      ...DEFAULT_GET_JSON_OPTIONS,
       ...this.connector.client.customOptions,
       ...customOptions,
     };
@@ -343,7 +346,7 @@ export class MySky {
     const publicKey = await this.userID();
     const dataKey = deriveDiscoverableFileTweak(path);
     // Do not hash the tweak anymore.
-    const opts = { ...defaultGetEntryOptions, hashedDataKeyHex: true };
+    const opts = { ...DEFAULT_GET_ENTRY_OPTIONS, hashedDataKeyHex: true };
 
     return await this.connector.client.registry.getEntryLink(publicKey, dataKey, opts);
   }
@@ -361,10 +364,10 @@ export class MySky {
   async setJSON(path: string, json: JsonData, customOptions?: CustomSetJSONOptions): Promise<JSONResponse> {
     validateString("path", path, "parameter");
     validateObject("json", json, "parameter");
-    validateOptionalObject("customOptions", customOptions, "parameter", defaultSetJSONOptions);
+    validateOptionalObject("customOptions", customOptions, "parameter", DEFAULT_SET_JSON_OPTIONS);
 
     const opts = {
-      ...defaultSetJSONOptions,
+      ...DEFAULT_SET_JSON_OPTIONS,
       ...this.connector.client.customOptions,
       ...customOptions,
     };
@@ -377,7 +380,7 @@ export class MySky {
 
     const signature = await this.signRegistryEntry(entry, path);
 
-    const setEntryOpts = extractOptions(opts, defaultSetEntryOptions);
+    const setEntryOpts = extractOptions(opts, DEFAULT_SET_ENTRY_OPTIONS);
     await this.connector.client.registry.postSignedEntry(publicKey, entry, signature, setEntryOpts);
 
     return { data: json, dataLink };
@@ -395,10 +398,10 @@ export class MySky {
   async setDataLink(path: string, dataLink: string, customOptions?: CustomSetJSONOptions): Promise<void> {
     validateString("path", path, "parameter");
     validateString("dataLink", dataLink, "parameter");
-    validateOptionalObject("customOptions", customOptions, "parameter", defaultSetJSONOptions);
+    validateOptionalObject("customOptions", customOptions, "parameter", DEFAULT_SET_JSON_OPTIONS);
 
     const opts = {
-      ...defaultSetJSONOptions,
+      ...DEFAULT_SET_JSON_OPTIONS,
       ...this.connector.client.customOptions,
       ...customOptions,
     };
@@ -407,7 +410,7 @@ export class MySky {
     const dataKey = deriveDiscoverableFileTweak(path);
     opts.hashedDataKeyHex = true; // Do not hash the tweak anymore.
 
-    const getEntryOpts = extractOptions(opts, defaultGetEntryOptions);
+    const getEntryOpts = extractOptions(opts, DEFAULT_GET_ENTRY_OPTIONS);
     const entry = await getNextRegistryEntry(
       this.connector.client,
       publicKey,
@@ -418,7 +421,7 @@ export class MySky {
 
     const signature = await this.signRegistryEntry(entry, path);
 
-    const setEntryOpts = extractOptions(opts, defaultSetEntryOptions);
+    const setEntryOpts = extractOptions(opts, DEFAULT_SET_ENTRY_OPTIONS);
     await this.connector.client.registry.postSignedEntry(publicKey, entry, signature, setEntryOpts);
   }
 
@@ -434,10 +437,10 @@ export class MySky {
    */
   async deleteJSON(path: string, customOptions?: CustomSetJSONOptions): Promise<void> {
     validateString("path", path, "parameter");
-    validateOptionalObject("customOptions", customOptions, "parameter", defaultSetJSONOptions);
+    validateOptionalObject("customOptions", customOptions, "parameter", DEFAULT_SET_JSON_OPTIONS);
 
     const opts = {
-      ...defaultSetJSONOptions,
+      ...DEFAULT_SET_JSON_OPTIONS,
       ...this.connector.client.customOptions,
       ...customOptions,
     };
@@ -446,7 +449,7 @@ export class MySky {
     const dataKey = deriveDiscoverableFileTweak(path);
     opts.hashedDataKeyHex = true; // Do not hash the tweak anymore.
 
-    const getEntryOpts = extractOptions(opts, defaultGetEntryOptions);
+    const getEntryOpts = extractOptions(opts, DEFAULT_GET_ENTRY_OPTIONS);
     const entry = await getNextRegistryEntry(
       this.connector.client,
       publicKey,
@@ -457,7 +460,7 @@ export class MySky {
 
     const signature = await this.signRegistryEntry(entry, path);
 
-    const setEntryOpts = extractOptions(opts, defaultSetEntryOptions);
+    const setEntryOpts = extractOptions(opts, DEFAULT_SET_ENTRY_OPTIONS);
     await this.connector.client.registry.postSignedEntry(publicKey, entry, signature, setEntryOpts);
   }
 
@@ -472,10 +475,10 @@ export class MySky {
    */
   async getEntryData(path: string, customOptions?: CustomGetEntryOptions): Promise<EntryData> {
     validateString("path", path, "parameter");
-    validateOptionalObject("customOptions", customOptions, "parameter", defaultGetEntryOptions);
+    validateOptionalObject("customOptions", customOptions, "parameter", DEFAULT_GET_ENTRY_OPTIONS);
 
     const opts = {
-      ...defaultGetEntryOptions,
+      ...DEFAULT_GET_ENTRY_OPTIONS,
       ...this.connector.client.customOptions,
       ...customOptions,
     };
@@ -505,7 +508,7 @@ export class MySky {
   async setEntryData(path: string, data: Uint8Array, customOptions?: CustomSetJSONOptions): Promise<EntryData> {
     validateString("path", path, "parameter");
     validateUint8Array("data", data, "parameter");
-    validateOptionalObject("customOptions", customOptions, "parameter", defaultSetEntryOptions);
+    validateOptionalObject("customOptions", customOptions, "parameter", DEFAULT_SET_ENTRY_OPTIONS);
 
     if (data.length > MAX_ENTRY_LENGTH) {
       throwValidationError(
@@ -517,7 +520,7 @@ export class MySky {
     }
 
     const opts = {
-      ...defaultSetJSONOptions,
+      ...DEFAULT_SET_JSON_OPTIONS,
       ...this.connector.client.customOptions,
       ...customOptions,
     };
@@ -526,12 +529,12 @@ export class MySky {
     const dataKey = deriveDiscoverableFileTweak(path);
     opts.hashedDataKeyHex = true; // Do not hash the tweak anymore.
 
-    const getEntryOpts = extractOptions(opts, defaultGetEntryOptions);
+    const getEntryOpts = extractOptions(opts, DEFAULT_GET_ENTRY_OPTIONS);
     const entry = await getNextRegistryEntry(this.connector.client, publicKey, dataKey, data, getEntryOpts);
 
     const signature = await this.signRegistryEntry(entry, path);
 
-    const setEntryOpts = extractOptions(opts, defaultSetEntryOptions);
+    const setEntryOpts = extractOptions(opts, DEFAULT_SET_ENTRY_OPTIONS);
     await this.connector.client.registry.postSignedEntry(publicKey, entry, signature, setEntryOpts);
 
     return { data: entry.data };
@@ -568,10 +571,10 @@ export class MySky {
    */
   async getJSONEncrypted(path: string, customOptions?: CustomGetJSONOptions): Promise<EncryptedJSONResponse> {
     validateString("path", path, "parameter");
-    validateOptionalObject("customOptions", customOptions, "parameter", defaultGetJSONOptions);
+    validateOptionalObject("customOptions", customOptions, "parameter", DEFAULT_GET_JSON_OPTIONS);
 
     const opts = {
-      ...defaultGetJSONOptions,
+      ...DEFAULT_GET_JSON_OPTIONS,
       ...this.connector.client.customOptions,
       ...customOptions,
       hashedDataKeyHex: true, // Do not hash the tweak anymore.
@@ -610,10 +613,10 @@ export class MySky {
   ): Promise<EncryptedJSONResponse> {
     validateString("path", path, "parameter");
     validateObject("json", json, "parameter");
-    validateOptionalObject("customOptions", customOptions, "parameter", defaultSetJSONOptions);
+    validateOptionalObject("customOptions", customOptions, "parameter", DEFAULT_SET_JSON_OPTIONS);
 
     const opts = {
-      ...defaultSetJSONOptions,
+      ...DEFAULT_SET_JSON_OPTIONS,
       ...this.connector.client.customOptions,
       ...customOptions,
     };
@@ -632,7 +635,7 @@ export class MySky {
     // Call MySky which checks for write permissions on the path.
     const signature = await this.signEncryptedRegistryEntry(entry, path);
 
-    const setEntryOpts = extractOptions(opts, defaultSetEntryOptions);
+    const setEntryOpts = extractOptions(opts, DEFAULT_SET_ENTRY_OPTIONS);
     await this.connector.client.registry.postSignedEntry(publicKey, entry, signature, setEntryOpts);
 
     return { data: json };

--- a/src/mysky/tweak.ts
+++ b/src/mysky/tweak.ts
@@ -1,7 +1,7 @@
 import { hashAll } from "../crypto";
 import { stringToUint8ArrayUtf8, toHexString } from "../utils/string";
 
-const discoverableBucketTweakVersion = 1;
+const DISCOVERABLE_BUCKET_TWEAK_VERSION = 1;
 
 /**
  * Derives the discoverable file tweak for the given path.
@@ -22,7 +22,7 @@ export class DiscoverableBucketTweak {
   constructor(path: string) {
     const paths = splitPath(path);
     const pathHashes = paths.map(hashPathComponent);
-    this.version = discoverableBucketTweakVersion;
+    this.version = DISCOVERABLE_BUCKET_TWEAK_VERSION;
     this.path = pathHashes;
   }
 

--- a/src/pin.ts
+++ b/src/pin.ts
@@ -2,7 +2,7 @@ import { AxiosResponse } from "axios";
 import { SkynetClient } from "./client";
 import { formatSkylink } from "./skylink/format";
 import { parseSkylink } from "./skylink/parse";
-import { BaseCustomOptions, defaultBaseOptions } from "./utils/options";
+import { BaseCustomOptions, DEFAULT_BASE_OPTIONS } from "./utils/options";
 import { validateSkylinkString, validateString } from "./utils/validation";
 
 /**
@@ -24,15 +24,10 @@ export type PinResponse = {
 };
 
 export const DEFAULT_PIN_OPTIONS = {
-  ...defaultBaseOptions,
+  ...DEFAULT_BASE_OPTIONS,
 
   endpointPin: "/skynet/pin",
 };
-
-/**
- * @deprecated please use DEFAULT_PIN_OPTIONS.
- */
-export const defaultPinOptions = DEFAULT_PIN_OPTIONS;
 
 /**
  * Re-pins the given skylink.
@@ -50,7 +45,7 @@ export async function pinSkylink(
 ): Promise<PinResponse> {
   const skylink = validateSkylinkString("skylinkUrl", skylinkUrl, "parameter");
 
-  const opts = { ...defaultPinOptions, ...this.customOptions, ...customOptions };
+  const opts = { ...DEFAULT_PIN_OPTIONS, ...this.customOptions, ...customOptions };
 
   // Don't include the path since the endpoint doesn't support it.
   const path = parseSkylink(skylinkUrl, { onlyPath: true });

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -4,7 +4,7 @@ import { sign } from "tweetnacl";
 
 import { SkynetClient } from "./client";
 import { assertUint64 } from "./utils/number";
-import { BaseCustomOptions, defaultBaseOptions } from "./utils/options";
+import { BaseCustomOptions, DEFAULT_BASE_OPTIONS } from "./utils/options";
 import { ensurePrefix, hexToUint8Array, isHexString, toHexString, trimPrefix } from "./utils/string";
 import { addUrlQuery, makeUrl } from "./utils/url";
 import { hashDataKey, hashRegistryEntry, Signature } from "./crypto";
@@ -43,26 +43,16 @@ export type CustomSetEntryOptions = BaseCustomOptions & {
 };
 
 export const DEFAULT_GET_ENTRY_OPTIONS = {
-  ...defaultBaseOptions,
+  ...DEFAULT_BASE_OPTIONS,
   endpointGetEntry: "/skynet/registry",
   hashedDataKeyHex: false,
 };
 
-/**
- * @deprecated please use DEFAULT_GET_ENTRY_OPTIONS.
- */
-export const defaultGetEntryOptions = DEFAULT_GET_ENTRY_OPTIONS;
-
 export const DEFAULT_SET_ENTRY_OPTIONS = {
-  ...defaultBaseOptions,
+  ...DEFAULT_BASE_OPTIONS,
   endpointSetEntry: "/skynet/registry",
   hashedDataKeyHex: false,
 };
-
-/**
- * @deprecated please use DEFAULT_SET_ENTRY_OPTIONS.
- */
-export const defaultSetEntryOptions = DEFAULT_SET_ENTRY_OPTIONS;
 
 export const DEFAULT_GET_ENTRY_TIMEOUT = 5; // 5 seconds
 
@@ -72,23 +62,9 @@ export const DEFAULT_GET_ENTRY_TIMEOUT = 5; // 5 seconds
 export const REGEX_REVISION_NO_QUOTES = /"revision":\s*([0-9]+)/;
 
 /**
- * Regex for JSON revision value without quotes.
- *
- * @deprecated please use REGEX_REVISION_NO_QUOTES.
- */
-export const regexRevisionNoQuotes = REGEX_REVISION_NO_QUOTES;
-
-/**
  * Regex for JSON revision value with quotes.
  */
 const REGEX_REVISION_WITH_QUOTES = /"revision":\s*"([0-9]+)"/;
-
-/**
- * Regex for JSON revision value with quotes.
- *
- * @deprecated please use REGEX_REVISION_WITH_QUOTES.
- */
-const regexRevisionWithQuotes = REGEX_REVISION_WITH_QUOTES;
 
 const ED25519_PREFIX = "ed25519:";
 
@@ -135,7 +111,7 @@ export async function getEntry(
   // Validation is done in `getEntryUrl`.
 
   const opts = {
-    ...defaultGetEntryOptions,
+    ...DEFAULT_GET_ENTRY_OPTIONS,
     ...this.customOptions,
     ...customOptions,
   };
@@ -156,7 +132,7 @@ export async function getEntry(
           return {};
         }
         // Change the revision value from a JSON integer to a string.
-        data = data.replace(regexRevisionNoQuotes, '"revision":"$1"');
+        data = data.replace(REGEX_REVISION_NO_QUOTES, '"revision":"$1"');
         // Try converting the JSON data to an object.
         try {
           return JSON.parse(data);
@@ -232,7 +208,7 @@ export async function getEntryUrl(
   // Validation is done in `getEntryUrlForPortal`.
 
   const opts = {
-    ...defaultGetEntryOptions,
+    ...DEFAULT_GET_ENTRY_OPTIONS,
     ...this.customOptions,
     ...customOptions,
   };
@@ -261,10 +237,10 @@ export function getEntryUrlForPortal(
   validateString("portalUrl", portalUrl, "parameter");
   validatePublicKey("publicKey", publicKey, "parameter");
   validateString("dataKey", dataKey, "parameter");
-  validateOptionalObject("customOptions", customOptions, "parameter", defaultGetEntryOptions);
+  validateOptionalObject("customOptions", customOptions, "parameter", DEFAULT_GET_ENTRY_OPTIONS);
 
   const opts = {
-    ...defaultGetEntryOptions,
+    ...DEFAULT_GET_ENTRY_OPTIONS,
     ...customOptions,
   };
 
@@ -304,10 +280,10 @@ export async function getEntryLink(
 ): Promise<string> {
   validatePublicKey("publicKey", publicKey, "parameter");
   validateString("dataKey", dataKey, "parameter");
-  validateOptionalObject("customOptions", customOptions, "parameter", defaultGetEntryOptions);
+  validateOptionalObject("customOptions", customOptions, "parameter", DEFAULT_GET_ENTRY_OPTIONS);
 
   const opts = {
-    ...defaultGetEntryOptions,
+    ...DEFAULT_GET_ENTRY_OPTIONS,
     ...customOptions,
   };
 
@@ -341,13 +317,13 @@ export async function setEntry(
 ): Promise<void> {
   validateHexString("privateKey", privateKey, "parameter");
   validateRegistryEntry("entry", entry, "parameter");
-  validateOptionalObject("customOptions", customOptions, "parameter", defaultSetEntryOptions);
+  validateOptionalObject("customOptions", customOptions, "parameter", DEFAULT_SET_ENTRY_OPTIONS);
 
   // Assert the input is 64 bits.
   assertUint64(entry.revision);
 
   const opts = {
-    ...defaultSetEntryOptions,
+    ...DEFAULT_SET_ENTRY_OPTIONS,
     ...this.customOptions,
     ...customOptions,
   };
@@ -401,10 +377,10 @@ export async function postSignedEntry(
   validateHexString("publicKey", publicKey, "parameter");
   validateRegistryEntry("entry", entry, "parameter");
   validateUint8Array("signature", signature, "parameter");
-  validateOptionalObject("customOptions", customOptions, "parameter", defaultSetEntryOptions);
+  validateOptionalObject("customOptions", customOptions, "parameter", DEFAULT_SET_ENTRY_OPTIONS);
 
   const opts = {
-    ...defaultSetEntryOptions,
+    ...DEFAULT_SET_ENTRY_OPTIONS,
     ...this.customOptions,
     ...customOptions,
   };
@@ -440,7 +416,7 @@ export async function postSignedEntry(
       // Convert the object data to JSON.
       const json = JSON.stringify(data);
       // Change the revision value from a string to a JSON integer.
-      return json.replace(regexRevisionWithQuotes, '"revision":$1');
+      return json.replace(REGEX_REVISION_WITH_QUOTES, '"revision":$1');
     },
   });
 }

--- a/src/skydb.test.ts
+++ b/src/skydb.test.ts
@@ -3,22 +3,22 @@ import MockAdapter from "axios-mock-adapter";
 
 import { getSkylinkUrlForPortal } from "./download";
 import { MAX_REVISION } from "./utils/number";
-import { defaultSkynetPortalUrl, uriSkynetPrefix } from "./utils/url";
+import { DEFAULT_SKYNET_PORTAL_URL, URI_SKYNET_PREFIX } from "./utils/url";
 import { SkynetClient, genKeyPairFromSeed } from "./index";
-import { getEntryUrlForPortal, regexRevisionNoQuotes } from "./registry";
+import { getEntryUrlForPortal, REGEX_REVISION_NO_QUOTES } from "./registry";
 import { checkCachedDataLink } from "./skydb";
 
 const { publicKey, privateKey } = genKeyPairFromSeed("insecure test seed");
 const dataKey = "app";
 const skylink = "CABAB_1Dt0FJsxqsu_J4TodNCbCGvtFf1Uys_3EgzOlTcg";
-const sialink = `${uriSkynetPrefix}${skylink}`;
+const sialink = `${URI_SKYNET_PREFIX}${skylink}`;
 const jsonData = { data: "thisistext" };
 const fullJsonData = { _data: jsonData, _v: 2 };
 const legacyJsonData = jsonData;
 const merkleroot = "QAf9Q7dBSbMarLvyeE6HTQmwhr7RX9VMrP9xIMzpU3I";
 const bitfield = 2048;
 
-const portalUrl = defaultSkynetPortalUrl;
+const portalUrl = DEFAULT_SKYNET_PORTAL_URL;
 const client = new SkynetClient(portalUrl);
 const registryUrl = `${portalUrl}/skynet/registry`;
 const registryLookupUrl = getEntryUrlForPortal(portalUrl, publicKey, dataKey);
@@ -197,7 +197,7 @@ describe("setJSON", () => {
         "18c76e88141c7cc76d8a77abcd91b5d64d8fc3833eae407ab8a5339e5fcf7940e3fa5830a8ad9439a0c0cc72236ed7b096ae05772f81eee120cbd173bfd6600e",
     };
     // Replace the quotes around the stringed bigint.
-    const json = JSON.stringify(entryData).replace(regexRevisionNoQuotes, '"revision":"$1"');
+    const json = JSON.stringify(entryData).replace(REGEX_REVISION_NO_QUOTES, '"revision":"$1"');
     mock.onGet(registryLookupUrl).reply(200, json);
 
     // mock a successful registry update

--- a/src/skydb.ts
+++ b/src/skydb.ts
@@ -46,7 +46,8 @@ export type JsonFullData = {
 const JSON_RESPONSE_VERSION = 2;
 
 /**
- * Custom get JSON options.
+ * Custom get JSON options. Includes the options for get entry, to get the
+ * skylink; and download, to download the file from the skylink.
  *
  * @property [cachedDataLink] - The last known data link. If it hasn't changed, do not download the file contents again.
  */
@@ -55,6 +56,10 @@ export type CustomGetJSONOptions = CustomGetEntryOptions &
     cachedDataLink?: string;
   };
 
+/**
+ * The default options for get JSON. Includes the default get entry and download
+ * options.
+ */
 export const DEFAULT_GET_JSON_OPTIONS = {
   ...DEFAULT_BASE_OPTIONS,
   ...DEFAULT_GET_ENTRY_OPTIONS,
@@ -63,15 +68,21 @@ export const DEFAULT_GET_JSON_OPTIONS = {
 };
 
 /**
- * Custom set JSON options.
+ * Custom set JSON options. Includes the options for upload, to get the file for
+ * the skylink; get JSON, to retrieve the revision; and set entry, to set the
+ * entry with the skylink and revision.
  */
-export type CustomSetJSONOptions = CustomGetJSONOptions & CustomSetEntryOptions & CustomUploadOptions;
+export type CustomSetJSONOptions = CustomUploadOptions & CustomGetJSONOptions & CustomSetEntryOptions;
 
+/**
+ * The default options for set JSON. Includes the default upload, get JSON, and
+ * set entry options.
+ */
 export const DEFAULT_SET_JSON_OPTIONS = {
   ...DEFAULT_BASE_OPTIONS,
+  ...DEFAULT_UPLOAD_OPTIONS,
   ...DEFAULT_GET_JSON_OPTIONS,
   ...DEFAULT_SET_ENTRY_OPTIONS,
-  ...DEFAULT_UPLOAD_OPTIONS,
 };
 
 export type JSONResponse = {

--- a/src/skylink/format.ts
+++ b/src/skylink/format.ts
@@ -1,7 +1,7 @@
 import { BASE32_ENCODED_SKYLINK_SIZE, BASE64_ENCODED_SKYLINK_SIZE } from "./sia";
 import { decodeSkylinkBase32, decodeSkylinkBase64, encodeSkylinkBase32, encodeSkylinkBase64 } from "../utils/encoding";
 import { trimUriPrefix } from "../utils/string";
-import { uriSkynetPrefix } from "../utils/url";
+import { URI_SKYNET_PREFIX } from "../utils/url";
 import { validateStringLen } from "../utils/validation";
 
 /**
@@ -11,7 +11,7 @@ import { validateStringLen } from "../utils/validation";
  * @returns - The converted base32 skylink.
  */
 export function convertSkylinkToBase32(skylink: string): string {
-  skylink = trimUriPrefix(skylink, uriSkynetPrefix);
+  skylink = trimUriPrefix(skylink, URI_SKYNET_PREFIX);
   validateStringLen("skylink", skylink, "parameter", BASE64_ENCODED_SKYLINK_SIZE);
 
   const bytes = decodeSkylinkBase64(skylink);
@@ -25,7 +25,7 @@ export function convertSkylinkToBase32(skylink: string): string {
  * @returns - The converted base64 skylink.
  */
 export function convertSkylinkToBase64(skylink: string): string {
-  skylink = trimUriPrefix(skylink, uriSkynetPrefix);
+  skylink = trimUriPrefix(skylink, URI_SKYNET_PREFIX);
   validateStringLen("skylink", skylink, "parameter", BASE32_ENCODED_SKYLINK_SIZE);
 
   const bytes = decodeSkylinkBase32(skylink);
@@ -42,8 +42,8 @@ export function formatSkylink(skylink: string): string {
   if (skylink === "") {
     return skylink;
   }
-  if (!skylink.startsWith(uriSkynetPrefix)) {
-    skylink = `${uriSkynetPrefix}${skylink}`;
+  if (!skylink.startsWith(URI_SKYNET_PREFIX)) {
+    skylink = `${URI_SKYNET_PREFIX}${skylink}`;
   }
   return skylink;
 }

--- a/src/skylink/parse.ts
+++ b/src/skylink/parse.ts
@@ -1,7 +1,7 @@
 import parse from "url-parse";
 
 import { trimForwardSlash, trimSuffix, trimUriPrefix } from "../utils/string";
-import { uriSkynetPrefix } from "../utils/url";
+import { URI_SKYNET_PREFIX } from "../utils/url";
 import { validateOptionalObject, validateString } from "../utils/validation";
 
 /**
@@ -59,7 +59,7 @@ export function parseSkylink(skylinkUrl: string, customOptions?: ParseSkylinkOpt
   // Check for skylink prefixed with sia: or sia:// and extract it.
   // Example: sia:XABvi7JtJbQSMAcDwnUnmp2FKDPjg8_tTTFP4BwMSxVdEg
   // Example: sia://XABvi7JtJbQSMAcDwnUnmp2FKDPjg8_tTTFP4BwMSxVdEg
-  skylinkUrl = trimUriPrefix(skylinkUrl, uriSkynetPrefix);
+  skylinkUrl = trimUriPrefix(skylinkUrl, URI_SKYNET_PREFIX);
 
   // Check for direct base64 skylink match.
   const matchDirect = skylinkUrl.match(SKYLINK_DIRECT_REGEX);

--- a/src/skylink/sia.ts
+++ b/src/skylink/sia.ts
@@ -1,7 +1,7 @@
 import { hashAll } from "../crypto";
 import { decodeSkylinkBase64, encodeSkylinkBase64, encodePrefixedBytes, decodeSkylinkBase32 } from "../utils/encoding";
 import { hexToUint8Array, stringToUint8ArrayUtf8, trimUriPrefix } from "../utils/string";
-import { uriSkynetPrefix } from "../utils/url";
+import { URI_SKYNET_PREFIX } from "../utils/url";
 import { validateHexString, validateNumber, validateString, validateUint8ArrayLen } from "../utils/validation";
 
 /**
@@ -213,7 +213,7 @@ export function newSkylinkV2(siaPublicKey: SiaPublicKey, tweak: Uint8Array): Sia
  * @throws - Will throw if the skylink is not a V1 or V2 skylink string.
  */
 export function decodeSkylink(encoded: string): Uint8Array {
-  encoded = trimUriPrefix(encoded, uriSkynetPrefix);
+  encoded = trimUriPrefix(encoded, URI_SKYNET_PREFIX);
 
   let bytes;
   if (encoded.length === BASE32_ENCODED_SKYLINK_SIZE) {

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -2,7 +2,7 @@ import { AxiosResponse } from "axios";
 import { HttpRequest, Upload } from "tus-js-client";
 
 import { getFileMimeType } from "./utils/file";
-import { BaseCustomOptions, defaultBaseOptions } from "./utils/options";
+import { BaseCustomOptions, DEFAULT_BASE_OPTIONS } from "./utils/options";
 import { formatSkylink } from "./skylink/format";
 import { buildRequestHeaders, buildRequestUrl, SkynetClient } from "./client";
 import { throwValidationError, validateObject, validateOptionalObject, validateString } from "./utils/validation";
@@ -55,7 +55,7 @@ export type UploadRequestResponse = {
 };
 
 export const DEFAULT_UPLOAD_OPTIONS = {
-  ...defaultBaseOptions,
+  ...DEFAULT_BASE_OPTIONS,
 
   endpointUpload: "/skynet/skyfile",
   endpointLargeUpload: "/skynet/tus",
@@ -64,11 +64,6 @@ export const DEFAULT_UPLOAD_OPTIONS = {
   largeFileSize: TUS_CHUNK_SIZE,
   retryDelays: DEFAULT_TUS_RETRY_DELAYS,
 };
-
-/**
- * @deprecated please use DEFAULT_UPLOAD_OPTIONS.
- */
-export const defaultUploadOptions = DEFAULT_UPLOAD_OPTIONS;
 
 /**
  * Uploads a file to Skynet.
@@ -88,7 +83,7 @@ export async function uploadFile(
 ): Promise<UploadRequestResponse> {
   // Validation is done in `uploadFileRequest` or `uploadLargeFileRequest`.
 
-  const opts = { ...defaultUploadOptions, ...this.customOptions, ...customOptions };
+  const opts = { ...DEFAULT_UPLOAD_OPTIONS, ...this.customOptions, ...customOptions };
 
   if (file.size < opts.largeFileSize) {
     return this.uploadSmallFile(file, opts);
@@ -137,9 +132,9 @@ export async function uploadSmallFileRequest(
   customOptions?: CustomUploadOptions
 ): Promise<AxiosResponse> {
   validateFile("file", file, "parameter");
-  validateOptionalObject("customOptions", customOptions, "parameter", defaultUploadOptions);
+  validateOptionalObject("customOptions", customOptions, "parameter", DEFAULT_UPLOAD_OPTIONS);
 
-  const opts = { ...defaultUploadOptions, ...this.customOptions, ...customOptions };
+  const opts = { ...DEFAULT_UPLOAD_OPTIONS, ...this.customOptions, ...customOptions };
   const formData = new FormData();
 
   file = ensureFileObjectConsistency(file);
@@ -207,9 +202,9 @@ export async function uploadLargeFileRequest(
   customOptions?: CustomUploadOptions
 ): Promise<AxiosResponse> {
   validateFile("file", file, "parameter");
-  validateOptionalObject("customOptions", customOptions, "parameter", defaultUploadOptions);
+  validateOptionalObject("customOptions", customOptions, "parameter", DEFAULT_UPLOAD_OPTIONS);
 
-  const opts = { ...defaultUploadOptions, ...this.customOptions, ...customOptions };
+  const opts = { ...DEFAULT_UPLOAD_OPTIONS, ...this.customOptions, ...customOptions };
 
   // TODO: Add back upload options once they are implemented in skyd.
   const url = await buildRequestUrl(this, opts.endpointLargeUpload);
@@ -323,9 +318,9 @@ export async function uploadDirectoryRequest(
 ): Promise<AxiosResponse> {
   validateObject("directory", directory, "parameter");
   validateString("filename", filename, "parameter");
-  validateOptionalObject("customOptions", customOptions, "parameter", defaultUploadOptions);
+  validateOptionalObject("customOptions", customOptions, "parameter", DEFAULT_UPLOAD_OPTIONS);
 
-  const opts = { ...defaultUploadOptions, ...this.customOptions, ...customOptions };
+  const opts = { ...DEFAULT_UPLOAD_OPTIONS, ...this.customOptions, ...customOptions };
 
   const formData = new FormData();
   Object.entries(directory).forEach(([path, file]) => {

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -17,13 +17,6 @@ export const DEFAULT_BASE_OPTIONS = {
 };
 
 /**
- * The default base custom options.
- *
- * @deprecated please use DEFAULT_BASE_OPTIONS.
- */
-export const defaultBaseOptions = DEFAULT_BASE_OPTIONS;
-
-/**
  * Extract only the model's custom options from the given options.
  *
  * @param opts - The given options.

--- a/yarn.lock
+++ b/yarn.lock
@@ -789,14 +789,6 @@
     "@typescript-eslint/typescript-estree" "4.29.1"
     debug "^4.3.1"
 
-"@typescript-eslint/scope-manager@4.29.0":
-  version "4.29.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.29.0.tgz#cf5474f87321bedf416ef65839b693bddd838599"
-  integrity sha512-HPq7XAaDMM3DpmuijxLV9Io8/6pQnliiXMQUcAdjpJJSR+fdmbD/zHCd7hMkjJn04UQtCQBtshgxClzg6NIS2w==
-  dependencies:
-    "@typescript-eslint/types" "4.29.0"
-    "@typescript-eslint/visitor-keys" "4.29.0"
-
 "@typescript-eslint/scope-manager@4.29.1":
   version "4.29.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.29.1.tgz#f25da25bc6512812efa2ce5ebd36619d68e61358"
@@ -805,28 +797,10 @@
     "@typescript-eslint/types" "4.29.1"
     "@typescript-eslint/visitor-keys" "4.29.1"
 
-"@typescript-eslint/types@4.29.0":
-  version "4.29.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.29.0.tgz#c8f1a1e4441ea4aca9b3109241adbc145f7f8a4e"
-  integrity sha512-2YJM6XfWfi8pgU2HRhTp7WgRw78TCRO3dOmSpAvIQ8MOv4B46JD2chnhpNT7Jq8j0APlIbzO1Bach734xxUl4A==
-
 "@typescript-eslint/types@4.29.1":
   version "4.29.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.29.1.tgz#94cce6cf7cc83451df03339cda99d326be2feaf5"
   integrity sha512-Jj2yu78IRfw4nlaLtKjVaGaxh/6FhofmQ/j8v3NXmAiKafbIqtAPnKYrf0sbGjKdj0hS316J8WhnGnErbJ4RCA==
-
-"@typescript-eslint/typescript-estree@4.29.0":
-  version "4.29.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.0.tgz#af7ab547757b86c91bfdbc54ff86845410856256"
-  integrity sha512-8ZpNHDIOyqzzgZrQW9+xQ4k5hM62Xy2R4RPO3DQxMc5Rq5QkCdSpk/drka+DL9w6sXNzV5nrdlBmf8+x495QXQ==
-  dependencies:
-    "@typescript-eslint/types" "4.29.0"
-    "@typescript-eslint/visitor-keys" "4.29.0"
-    debug "^4.3.1"
-    globby "^11.0.3"
-    is-glob "^4.0.1"
-    semver "^7.3.5"
-    tsutils "^3.21.0"
 
 "@typescript-eslint/typescript-estree@4.29.1":
   version "4.29.1"
@@ -840,14 +814,6 @@
     is-glob "^4.0.1"
     semver "^7.3.5"
     tsutils "^3.21.0"
-
-"@typescript-eslint/visitor-keys@4.29.0":
-  version "4.29.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.0.tgz#1ff60f240def4d85ea68d4fd2e4e9759b7850c04"
-  integrity sha512-LoaofO1C/jAJYs0uEpYMXfHboGXzOJeV118X4OsZu9f7rG7Pr9B3+4HTU8+err81rADa4xfQmAxnRnPAI2jp+Q==
-  dependencies:
-    "@typescript-eslint/types" "4.29.0"
-    eslint-visitor-keys "^2.0.0"
 
 "@typescript-eslint/visitor-keys@4.29.1":
   version "4.29.1"


### PR DESCRIPTION
- Export new constants in addition to deprecated constants (users would get deprecation warning but the new constants were not available).
  - Exports constants `MAX_ENTRY_LENGTH, MYSKY_DOMAIN, MYSKY_DEV_DOMAIN, DEFAULT_SKYNET_PORTAL_URL, URI_HANDSHAKE_PREFIX, URI_SKYNET_PREFIX` and type `EntryData`
- Add some missing documentation
- Update usage of internal constants 