### PR TITLE
[BREAKING] Don't truncate the path seeds (for directories only)

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -192,12 +192,12 @@ export class SkynetClient {
     this.customOptions = customOptions;
   }
 
+  /* istanbul ignore next */
   /**
    * Make the request for the API portal URL.
    *
    * @returns - A promise that resolves when the request is complete.
    */
-  /* istanbul ignore next */
   async initPortalUrl(): Promise<void> {
     if (this.customPortalUrl) {
       // Tried to make a request for the API portal URL when a custom URL was already provided.
@@ -212,12 +212,12 @@ export class SkynetClient {
     return;
   }
 
+  /* istanbul ignore next */
   /**
    * Returns the API portal URL. Makes the request to get it if not done so already.
    *
    * @returns - the portal URL.
    */
-  /* istanbul ignore next */
   async portalUrl(): Promise<string> {
     if (this.customPortalUrl) {
       return this.customPortalUrl;

--- a/src/file.ts
+++ b/src/file.ts
@@ -2,8 +2,8 @@ import { SkynetClient } from "./client";
 import { EntryData } from "./mysky";
 import {
   decryptJSONFile,
-  deriveEncryptedFileKeyEntropy,
-  deriveEncryptedFileTweak,
+  deriveEncryptedPathKeyEntropy,
+  deriveEncryptedPathTweak,
   EncryptedJSONResponse,
 } from "./mysky/encrypted_files";
 import { deriveDiscoverableFileTweak } from "./mysky/tweak";
@@ -130,7 +130,7 @@ export async function getJSONEncrypted(
   customOptions?: CustomGetJSONOptions
 ): Promise<EncryptedJSONResponse> {
   validateString("userID", userID, "parameter");
-  // Full validation of the path seed is in `deriveEncryptedFileKeyEntropy` below.
+  // Full validation of the path seed is in `deriveEncryptedPathKeyEntropy` below.
   validateString("pathSeed", pathSeed, "parameter");
   validateOptionalObject("customOptions", customOptions, "parameter", DEFAULT_GET_JSON_OPTIONS);
 
@@ -142,10 +142,10 @@ export async function getJSONEncrypted(
   };
 
   // Validate the path seed and get the key.
-  const key = deriveEncryptedFileKeyEntropy(pathSeed);
+  const key = deriveEncryptedPathKeyEntropy(pathSeed);
 
   // Fetch the raw encrypted JSON data.
-  const dataKey = deriveEncryptedFileTweak(pathSeed);
+  const dataKey = deriveEncryptedPathTweak(pathSeed);
   const { data } = await this.db.getRawBytes(userID, dataKey, opts);
   if (data === null) {
     return { data: null };

--- a/src/file.ts
+++ b/src/file.ts
@@ -2,8 +2,8 @@ import { SkynetClient } from "./client";
 import { EntryData } from "./mysky";
 import {
   decryptJSONFile,
-  deriveEncryptedPathKeyEntropy,
-  deriveEncryptedPathTweak,
+  deriveEncryptedFileKeyEntropy,
+  deriveEncryptedFileTweak,
   EncryptedJSONResponse,
 } from "./mysky/encrypted_files";
 import { deriveDiscoverableFileTweak } from "./mysky/tweak";
@@ -109,12 +109,12 @@ export async function getEntryData(
 // ===============
 
 /**
- * Gets Encrypted JSON set with MySky at the given data path for the given
+ * Gets Encrypted JSON set with MySky for the given file path seed for the given
  * public user ID.
  *
  * @param this - SkynetClient
  * @param userID - The MySky public user ID.
- * @param pathSeed - The share-able secret path seed.
+ * @param pathSeed - The share-able secret file path seed.
  * @param [customOptions] - Additional settings that can optionally be set.
  * @returns - An object containing the decrypted json data.
  */
@@ -126,7 +126,7 @@ export async function getJSONEncrypted(
   customOptions?: CustomGetJSONOptions
 ): Promise<EncryptedJSONResponse> {
   validateString("userID", userID, "parameter");
-  // Full validation of the path seed is in `deriveEncryptedPathKeyEntropy` below.
+  // Full validation of the path seed is in `deriveEncryptedFileKeyEntropy` below.
   validateString("pathSeed", pathSeed, "parameter");
   validateOptionalObject("customOptions", customOptions, "parameter", DEFAULT_GET_JSON_OPTIONS);
 
@@ -138,10 +138,10 @@ export async function getJSONEncrypted(
   };
 
   // Validate the path seed and get the key.
-  const key = deriveEncryptedPathKeyEntropy(pathSeed);
+  const key = deriveEncryptedFileKeyEntropy(pathSeed);
 
   // Fetch the raw encrypted JSON data.
-  const dataKey = deriveEncryptedPathTweak(pathSeed);
+  const dataKey = deriveEncryptedFileTweak(pathSeed);
   const { data } = await this.db.getRawBytes(userID, dataKey, opts);
   if (data === null) {
     return { data: null };

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,11 +24,15 @@ export {
   mySkyDevDomain,
 } from "./mysky";
 export {
+  deriveEncryptedPathKeyEntropy,
+  deriveEncryptedPathSeed,
+  deriveEncryptedPathTweak,
+  ENCRYPTION_PATH_SEED_DIRECTORY_LENGTH,
+  ENCRYPTION_PATH_SEED_FILE_LENGTH,
+  // Deprecated functions.
   deriveEncryptedFileKeyEntropy,
   deriveEncryptedFileSeed,
   deriveEncryptedFileTweak,
-  ENCRYPTION_PATH_SEED_DIRECTORY_LENGTH,
-  ENCRYPTION_PATH_SEED_FILE_LENGTH,
 } from "./mysky/encrypted_files";
 export { deriveDiscoverableFileTweak } from "./mysky/tweak";
 export { convertSkylinkToBase32, convertSkylinkToBase64 } from "./skylink/format";

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,8 @@ export {
   deriveEncryptedFileKeyEntropy,
   deriveEncryptedFileSeed,
   deriveEncryptedFileTweak,
-  ENCRYPTION_PATH_SEED_LENGTH,
+  ENCRYPTION_PATH_SEED_DIRECTORY_LENGTH,
+  ENCRYPTION_PATH_SEED_FILE_LENGTH,
 } from "./mysky/encrypted_files";
 export { deriveDiscoverableFileTweak } from "./mysky/tweak";
 export { convertSkylinkToBase32, convertSkylinkToBase64 } from "./skylink/format";

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,20 +19,19 @@ export {
   MAX_ENTRY_LENGTH,
   MySky,
   MYSKY_DOMAIN,
-  mySkyDomain,
   MYSKY_DEV_DOMAIN,
+  // Deprecated.
   mySkyDevDomain,
+  mySkyDomain,
 } from "./mysky";
 export {
-  deriveEncryptedPathKeyEntropy,
+  deriveEncryptedFileKeyEntropy,
+  deriveEncryptedFileTweak,
   deriveEncryptedPathSeed,
-  deriveEncryptedPathTweak,
   ENCRYPTION_PATH_SEED_DIRECTORY_LENGTH,
   ENCRYPTION_PATH_SEED_FILE_LENGTH,
-  // Deprecated functions.
-  deriveEncryptedFileKeyEntropy,
+  // Deprecated.
   deriveEncryptedFileSeed,
-  deriveEncryptedFileTweak,
 } from "./mysky/encrypted_files";
 export { deriveDiscoverableFileTweak } from "./mysky/tweak";
 export { DELETION_ENTRY_DATA } from "./skydb";
@@ -45,12 +44,13 @@ export { stringToUint8ArrayUtf8, uint8ArrayToStringUtf8 } from "./utils/string";
 export {
   defaultPortalUrl,
   DEFAULT_SKYNET_PORTAL_URL,
-  defaultSkynetPortalUrl,
   extractDomainForPortal,
   getFullDomainUrlForPortal,
   URI_HANDSHAKE_PREFIX,
-  uriHandshakePrefix,
   URI_SKYNET_PREFIX,
+  // Deprecated.
+  defaultSkynetPortalUrl,
+  uriHandshakePrefix,
   uriSkynetPrefix,
 } from "./utils/url";
 

--- a/src/mysky/encrypted_files.test.ts
+++ b/src/mysky/encrypted_files.test.ts
@@ -3,9 +3,9 @@ import { readFileSync } from "fs";
 import {
   checkPaddedBlock,
   decryptJSONFile,
-  deriveEncryptedFileKeyEntropy,
-  deriveEncryptedFileSeed,
-  deriveEncryptedFileTweak,
+  deriveEncryptedPathKeyEntropy,
+  deriveEncryptedPathSeed,
+  deriveEncryptedPathTweak,
   encodeEncryptedFileMetadata,
   ENCRYPTED_JSON_RESPONSE_VERSION,
   ENCRYPTION_KEY_LENGTH,
@@ -39,7 +39,7 @@ expect.extend({
   },
 });
 
-describe("deriveEncryptedFileKeyEntropy", () => {
+describe("deriveEncryptedPathKeyEntropy", () => {
   it("Should derive the correct encrypted file key entropy", () => {
     // Hard-code expected value to catch breaking changes.
     const pathSeed = "a".repeat(64);
@@ -48,13 +48,13 @@ describe("deriveEncryptedFileKeyEntropy", () => {
       94, 186, 244, 48, 171, 115, 171,
     ];
 
-    const result = deriveEncryptedFileKeyEntropy(pathSeed);
+    const result = deriveEncryptedPathKeyEntropy(pathSeed);
 
     expect(result).toEqualUint8Array(new Uint8Array(expectedEntropy));
   });
 });
 
-describe("deriveEncryptedFileSeed", () => {
+describe("deriveEncryptedPathSeed", () => {
   // Hard-code expected value to catch breaking changes.
   const pathSeed = "a".repeat(128);
   const subPath = "path/to/file.json";
@@ -64,24 +64,24 @@ describe("deriveEncryptedFileSeed", () => {
 
   it("should derive the correct encrypted file seed for a file", () => {
     // Derive seed for a file.
-    const fileSeed = deriveEncryptedFileSeed(pathSeed, subPath, false);
+    const fileSeed = deriveEncryptedPathSeed(pathSeed, subPath, false);
 
     expect(fileSeed).toEqual(expectedFileSeed);
   });
 
   it("should derive the correct encrypted file seed for a directory", () => {
     // Derive seed for a directory.
-    const directorySeed = deriveEncryptedFileSeed(pathSeed, subPath, true);
+    const directorySeed = deriveEncryptedPathSeed(pathSeed, subPath, true);
 
     expect(directorySeed).toEqual(expectedDirectorySeed);
   });
 
   it("should result in the same path seed when deriving path for directory first", () => {
     // Derive seed for directory first.
-    const directorySeed = deriveEncryptedFileSeed(pathSeed, "path/to", true);
+    const directorySeed = deriveEncryptedPathSeed(pathSeed, "path/to", true);
 
     // Derive seed for file.
-    const fileSeed = deriveEncryptedFileSeed(directorySeed, "file.json", false);
+    const fileSeed = deriveEncryptedPathSeed(directorySeed, "file.json", false);
 
     expect(fileSeed).toEqual(expectedFileSeed);
   });
@@ -90,23 +90,23 @@ describe("deriveEncryptedFileSeed", () => {
     const pathSeed = "a".repeat(128);
     const subPath = "";
 
-    expect(() => deriveEncryptedFileSeed(pathSeed, subPath, false)).toThrowError("Input subPath '' not a valid path");
+    expect(() => deriveEncryptedPathSeed(pathSeed, subPath, false)).toThrowError("Input subPath '' not a valid path");
   });
 
   it("should throw for a file path seed", () => {
     const pathSeed = "a".repeat(64);
 
-    expect(() => deriveEncryptedFileSeed(pathSeed, subPath, false)).toThrowError(
+    expect(() => deriveEncryptedPathSeed(pathSeed, subPath, false)).toThrowError(
       "Expected parameter 'pathSeed' to be a directory path seed of length '128', was type 'string', value 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'"
     );
   });
 });
 
-describe("deriveEncryptedFileTweak", () => {
+describe("deriveEncryptedPathTweak", () => {
   it("should throw if an invalid seed is provided", () => {
     const seed = "test.hns/foo";
 
-    expect(() => deriveEncryptedFileTweak(seed)).toThrowError(
+    expect(() => deriveEncryptedPathTweak(seed)).toThrowError(
       "Expected parameter 'pathSeed' to be a valid file or directory path seed of length '64' or '128', was type 'string', value 'test.hns/foo'"
     );
   });
@@ -116,7 +116,7 @@ describe("deriveEncryptedFileTweak", () => {
     const pathSeed = "b".repeat(64);
     const expectedTweak = "bf7f0e6566234184541e44ad2b2084ca207132a90a7b927e05fef9d24789caa7";
 
-    const result = deriveEncryptedFileTweak(pathSeed);
+    const result = deriveEncryptedPathTweak(pathSeed);
 
     expect(result).toEqual(expectedTweak);
   });

--- a/src/mysky/encrypted_files.test.ts
+++ b/src/mysky/encrypted_files.test.ts
@@ -55,22 +55,26 @@ describe("deriveEncryptedFileKeyEntropy", () => {
 });
 
 describe("deriveEncryptedFileSeed", () => {
-  it("Should derive the correct encrypted file seed", () => {
-    // Hard-code expected value to catch breaking changes.
-    const pathSeed = "a".repeat(64);
-    const subPath = "path/to/file.json";
+  // Hard-code expected value to catch breaking changes.
+  const pathSeed = "a".repeat(64);
+  const subPath = "path/to/file.json";
 
+  it("Should derive the correct encrypted file seed for a file", () => {
     // Derive seed for a file.
     const fileSeed = deriveEncryptedFileSeed(pathSeed, subPath, false);
 
-    expect(fileSeed).toEqual("ace80613629a4049386b3007c17aa9aa2a7f86a7649326c03d56eb40df23593b");
+    expect(fileSeed).toEqual(
+      "ace80613629a4049386b3007c17aa9aa2a7f86a7649326c03d56eb40df23593bee4a19fc4dcf5118c2cf85649551a780acf07b7b2d13e098612351e59c472bd0"
+    );
+  });
 
+  it("Should derive the correct encrypted file seed for a directory", () => {
     // Derive seed for a directory.
     const directorySeed = deriveEncryptedFileSeed(pathSeed, subPath, true);
 
-    expect(directorySeed).toEqual("fa91607af922c9e57d794b7980e550fb15db99e62960fb0908b0f5af10afaf16");
-
-    expect(fileSeed).not.toEqual(directorySeed);
+    expect(directorySeed).toEqual(
+      "fa91607af922c9e57d794b7980e550fb15db99e62960fb0908b0f5af10afaf16876b7ac314c1815eb1ca0e51701c11489f08002e8ff3d61c7798bed1c7f016fb"
+    );
   });
 
   it("Should throw for invalid sub path", () => {

--- a/src/mysky/encrypted_files.ts
+++ b/src/mysky/encrypted_files.ts
@@ -47,7 +47,7 @@ const ENCRYPTION_OVERHEAD_LENGTH = 16;
 /**
  * The length of the share-able path seed.
  */
-export const ENCRYPTION_PATH_SEED_LENGTH = 32;
+export const ENCRYPTION_PATH_SEED_LENGTH = 64;
 
 // Descriptive salt that should not be changed.
 const SALT_ENCRYPTED_CHILD = "encrypted filesystem child";
@@ -222,8 +222,8 @@ export function deriveEncryptedFileSeed(pathSeed: string, subPath: string, isDir
     pathSeedBytes = sha512(bytes);
   });
 
-  // Truncate and hex-encode the final output.
-  return toHexString(pathSeedBytes.slice(0, ENCRYPTION_PATH_SEED_LENGTH));
+  // Hex-encode the final output.
+  return toHexString(pathSeedBytes);
 }
 
 /**

--- a/src/mysky/encrypted_files.ts
+++ b/src/mysky/encrypted_files.ts
@@ -3,13 +3,7 @@ import { sanitizePath } from "skynet-mysky-utils";
 import { secretbox } from "tweetnacl";
 
 import { HASH_LENGTH, sha512 } from "../crypto";
-import {
-  hexToUint8Array,
-  isHexString,
-  stringToUint8ArrayUtf8,
-  toHexString,
-  uint8ArrayToStringUtf8,
-} from "../utils/string";
+import { hexToUint8Array, stringToUint8ArrayUtf8, toHexString, uint8ArrayToStringUtf8 } from "../utils/string";
 import { JsonData } from "../utils/types";
 import {
   throwValidationError,
@@ -192,7 +186,7 @@ export function deriveEncryptedFileKeyEntropy(pathSeed: string): Uint8Array {
  */
 export function deriveEncryptedPathKeyEntropy(pathSeed: string): Uint8Array {
   // Validate the path seed and get bytes.
-  const pathSeedBytes = validateAndGetFilePathSeedBytes(pathSeed);
+  const pathSeedBytes = validateAndGetPathSeedBytes(pathSeed);
 
   const bytes = new Uint8Array([...sha512(SALT_ENCRYPTION), ...sha512(pathSeedBytes)]);
   const hashBytes = sha512(bytes);
@@ -219,7 +213,7 @@ export function deriveEncryptedFileTweak(pathSeed: string): string {
  */
 export function deriveEncryptedPathTweak(pathSeed: string): string {
   // Validate the path seed and get bytes.
-  const pathSeedBytes = validateAndGetFilePathSeedBytes(pathSeed);
+  const pathSeedBytes = validateAndGetPathSeedBytes(pathSeed);
 
   let hashBytes = sha512(new Uint8Array([...sha512(SALT_ENCRYPTED_TWEAK), ...sha512(pathSeedBytes)]));
   // Truncate the hash or it will be rejected in skyd.
@@ -423,12 +417,11 @@ export function encodeEncryptedFileMetadata(metadata: EncryptedFileMetadata): Ui
  * @param pathSeed - The given path seed.
  * @returns - The path seed bytes.
  */
-function validateAndGetFilePathSeedBytes(pathSeed: string): Uint8Array {
-  if (
-    (pathSeed.length !== ENCRYPTION_PATH_SEED_DIRECTORY_LENGTH &&
-      pathSeed.length !== ENCRYPTION_PATH_SEED_FILE_LENGTH) ||
-    !isHexString(pathSeed)
-  ) {
+function validateAndGetPathSeedBytes(pathSeed: string): Uint8Array {
+  validateHexString("pathSeed", pathSeed, "parameter");
+
+  const acceptedLengths = [ENCRYPTION_PATH_SEED_FILE_LENGTH, ENCRYPTION_PATH_SEED_DIRECTORY_LENGTH];
+  if (!acceptedLengths.includes(pathSeed.length)) {
     throwValidationError(
       "pathSeed",
       pathSeed,

--- a/src/mysky/encrypted_files.ts
+++ b/src/mysky/encrypted_files.ts
@@ -178,8 +178,19 @@ export function encryptJSONFile(json: JsonData, metadata: EncryptedFileMetadata,
  *
  * @param pathSeed - The given path seed.
  * @returns - The key entropy.
+ * @deprecated - This function has been deprecated in favor of deriveEncryptedPathKeyEntropy.
  */
 export function deriveEncryptedFileKeyEntropy(pathSeed: string): Uint8Array {
+  return deriveEncryptedPathKeyEntropy(pathSeed);
+}
+
+/**
+ * Derives key entropy for the given path seed.
+ *
+ * @param pathSeed - The given path seed.
+ * @returns - The key entropy.
+ */
+export function deriveEncryptedPathKeyEntropy(pathSeed: string): Uint8Array {
   // Validate the path seed and get bytes.
   const pathSeedBytes = validateAndGetFilePathSeedBytes(pathSeed);
 
@@ -194,8 +205,19 @@ export function deriveEncryptedFileKeyEntropy(pathSeed: string): Uint8Array {
  *
  * @param pathSeed - the given path seed.
  * @returns - The encrypted file tweak.
+ * @deprecated - This function has been deprecated in favor of deriveEncryptedPathTweak.
  */
 export function deriveEncryptedFileTweak(pathSeed: string): string {
+  return deriveEncryptedPathTweak(pathSeed);
+}
+
+/**
+ * Derives the encrypted file tweak for the given path seed.
+ *
+ * @param pathSeed - the given path seed.
+ * @returns - The encrypted file tweak.
+ */
+export function deriveEncryptedPathTweak(pathSeed: string): string {
   // Validate the path seed and get bytes.
   const pathSeedBytes = validateAndGetFilePathSeedBytes(pathSeed);
 
@@ -215,8 +237,24 @@ export function deriveEncryptedFileTweak(pathSeed: string): string {
  * @param isDirectory - Whether the path is a directory.
  * @returns - The path seed for the given path.
  * @throws - Will throw if the input sub path is not a valid path.
+ * @deprecated - This function has been deprecated in favor of deriveEncryptedPathSeed.
  */
 export function deriveEncryptedFileSeed(pathSeed: string, subPath: string, isDirectory: boolean): string {
+  return deriveEncryptedPathSeed(pathSeed, subPath, isDirectory);
+}
+
+/**
+ * Derives the path seed for the relative path, given the starting path seed and
+ * whether it is a directory. The path can be an absolute path if the root seed
+ * is given.
+ *
+ * @param pathSeed - The given starting path seed.
+ * @param subPath - The path.
+ * @param isDirectory - Whether the path is a directory.
+ * @returns - The path seed for the given path.
+ * @throws - Will throw if the input sub path is not a valid path.
+ */
+export function deriveEncryptedPathSeed(pathSeed: string, subPath: string, isDirectory: boolean): string {
   validateHexString("pathSeed", pathSeed, "parameter");
   validateString("subPath", subPath, "parameter");
   validateBoolean("isDirectory", isDirectory, "parameter");

--- a/src/mysky/index.ts
+++ b/src/mysky/index.ts
@@ -50,8 +50,8 @@ import {
 import { decodeSkylink, RAW_SKYLINK_SIZE } from "../skylink/sia";
 import {
   decryptJSONFile,
-  deriveEncryptedFileKeyEntropy,
-  deriveEncryptedFileTweak,
+  deriveEncryptedPathKeyEntropy,
+  deriveEncryptedPathTweak,
   EncryptedJSONResponse,
   ENCRYPTED_JSON_RESPONSE_VERSION,
   encryptJSONFile,
@@ -599,13 +599,13 @@ export class MySky {
     const [publicKey, pathSeed] = await Promise.all([this.userID(), this.getEncryptedFileSeed(path, false)]);
 
     // Fetch the raw encrypted JSON data.
-    const dataKey = deriveEncryptedFileTweak(pathSeed);
+    const dataKey = deriveEncryptedPathTweak(pathSeed);
     const { data } = await this.connector.client.db.getRawBytes(publicKey, dataKey, opts);
     if (data === null) {
       return { data: null };
     }
 
-    const encryptionKey = deriveEncryptedFileKeyEntropy(pathSeed);
+    const encryptionKey = deriveEncryptedPathKeyEntropy(pathSeed);
     const json = decryptJSONFile(data, encryptionKey);
 
     return { data: json };
@@ -638,9 +638,9 @@ export class MySky {
 
     // Call MySky which checks for read permissions on the path.
     const [publicKey, pathSeed] = await Promise.all([this.userID(), this.getEncryptedFileSeed(path, false)]);
-    const dataKey = deriveEncryptedFileTweak(pathSeed);
+    const dataKey = deriveEncryptedPathTweak(pathSeed);
     opts.hashedDataKeyHex = true; // Do not hash the tweak anymore.
-    const encryptionKey = deriveEncryptedFileKeyEntropy(pathSeed);
+    const encryptionKey = deriveEncryptedPathKeyEntropy(pathSeed);
 
     // Pad and encrypt json file.
     const data = encryptJSONFile(json, { version: ENCRYPTED_JSON_RESPONSE_VERSION }, encryptionKey);


### PR DESCRIPTION
# PULL REQUEST

## Todo

- [ ] We will have to update MySky before this takes effect.

## BREAKING CHANGES

- Path seeds for directories are now 64 bytes rather than 32.
- Old directory path seeds cannot be passed in to `deriveEncryptedFileSeed`.
- The `ENCRYPTION_PATH_SEED_LENGTH` constant has been removed in favor of `ENCRYPTION_PATH_SEED_DIRECTORY_LENGTH` and `ENCRYPTION_PATH_SEED_FILE_LENGTH`

## Other Changes

- Mark `deriveEncryptedFileSeed` and `mySky.getEncryptedFileSeed` as deprecated and point users to
`deriveEncryptedPathSeed` and `mySky.getEncryptedPathSeed` instead. The original function names implied that they
only work on files when they work for folders too.
- Validation has been added to `deriveEncryptedFileKeyEntropy` and
`deriveEncryptedFileTweak` so that they only accept file path seed inputs.

## About

The issue was that path seeds were 64 bytes internally for each directory and then truncated to 32 bytes at the end. For example, the path seed for `path/foo/bar.json` was 64 bytes for `path`, 64 for `foo` and 32 for `bar.json` (which is the final output). However, you could request the path seed for `path` which would give you the 32-byte truncated seed. If you then tried to use that and requested `foo/bar.json` for `path`, you would end up with a different seed than for `path/foo/bar.json`. The fix is to keep truncating to 32 bytes for files but to change the output to the full 64 bytes for directories.

Since the string is hex-encoded, the final string length is twice that (64 for files and 128 for dirs). It's not ideal to have such long path seed strings but we get to preserve compat for files. 

### Solution v2

The original solution in this PR was to remove the truncation altogether, so that both directories and files would be 64 bytes. This was breaking for both directories and files -- the new solution only breaks directories, which don't work anyways. Also, since dirs and files have different length path seeds, this solution has the advantage that you can use the length to tell them apart.