### PR TITLE
include tryfiles metadata for new release

### DIFF
--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -381,6 +381,7 @@ describe(`Integration test for portal '${portal}'`, () => {
       subfiles: {
         HelloWorld: { filename: dataKey, contenttype: plaintextType, len: fileData.length },
       },
+      tryfiles: ["index.html"],
     };
 
     it("Should upload and download directories", async () => {


### PR DESCRIPTION
new skyd feature adds "tryfiles" metadata by default to every new upload