### PR TITLE
Enable parallel tus uploads

### DIFF
--- a/src/upload.ts
+++ b/src/upload.ts
@@ -13,6 +13,11 @@ import { throwValidationError, validateObject, validateOptionalObject, validateS
 const TUS_CHUNK_SIZE = (1 << 22) * 10;
 
 /**
+ * A number indicating how many parts should be uploaded in parallel.
+ */
+const TUS_PARALLEL_UPLOADS = 2;
+
+/**
  * The retry delays, in ms. Data is stored in skyd for up to 20 minutes, so the
  * total delays should not exceed that length of time.
  */
@@ -225,6 +230,19 @@ export async function uploadLargeFileRequest(
       opts.onUploadProgress(progress, { loaded: bytesSent, total: bytesTotal });
     };
 
+  // Make an OPTIONS request to find out whether parallel uploads are supported.
+  // TODO: Remove this once parallel uploads are fully supported and rolled-out.
+  const resp = await this.executeRequest({
+    ...opts,
+    endpointPath: opts.endpointLargeUpload,
+    method: "options",
+  });
+
+  let parallelUploads = 1;
+  if (resp.headers["Tus-Extension"].contains("concatenation")) {
+    parallelUploads = TUS_PARALLEL_UPLOADS;
+  }
+
   return new Promise((resolve, reject) => {
     const tusOpts = {
       endpoint: url,
@@ -234,6 +252,7 @@ export async function uploadLargeFileRequest(
         filename,
         filetype: file.type,
       },
+      parallelUploads,
       headers,
       onProgress,
       onBeforeRequest: function (req: HttpRequest) {


### PR DESCRIPTION
# PULL REQUEST

## Overview

This is the client counterpart to https://gitlab.com/SkynetLabs/skyd/-/merge_requests/246. It enables parallel uploads with tus so that whenever one chunk is uploaded and waiting for `skyd`, another chunk can be uploaded in the meantime.

## Example for Visual Changes

<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist

Review and complete the checklist to ensure that the PR is complete before assigned to an approver.

- [x] All new methods or updated methods have clear docstrings
- [ ] Testing added or updated for new methods
- [x] Verify if any changes impact the WebPortal Health Checks
- [x] Approriate documentation updated
- [ ] Changelog file created

## Issues Closed

<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
