### PR TITLE
[BREAKING] Fix test NDFs by using server URL instead of portal URL

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -11,7 +11,7 @@ const config: Config.InitialOptions = {
   preset: "ts-jest",
 
   // From old package.json.
-  testTimeout: 60000,
+  testTimeout: 90000,
   // Automatically clear mock calls and instances between every test
   clearMocks: true,
   // An array of glob patterns indicating a set of files for which coverage information should be collected

--- a/src/client.ts
+++ b/src/client.ts
@@ -284,7 +284,7 @@ export class SkynetClient {
         "Did not get 'headers' in response despite a successful request. Please try again and report this issue to the devs if it persists."
       );
     }
-    const portalUrl = response.headers["skynet-portal-api"];
+    const portalUrl = response.headers["skynet-server-api"] || response.headers["skynet-portal-api"];
     if (!portalUrl) {
       throw new Error("Could not get portal URL for the given portal");
     }


### PR DESCRIPTION
# PULL REQUEST

## Overview

This change helps prevent cases where you would try to access data right after
uploading it and get routed to a different server by the load balancer. Now, you
will always be taken to the same server for the duration of the client's
lifetime.

**NOTE:** This is a breaking change because it changes the URLs generated by the
SDK and changes the return of `client.portalURL()`. For example, we probably
want skybin links to remain as `siasky.net/<skylink>` instead of
`us-va-1.siasky.net/<skylink>`. We may have to think this through more.