### PR TITLE
[NDF] Fix NDF in etag tests: downloading files just uploaded

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -11,7 +11,7 @@ const config: Config.InitialOptions = {
   preset: "ts-jest",
 
   // From old package.json.
-  testTimeout: 60000,
+  testTimeout: 90000,
   // Automatically clear mock calls and instances between every test
   clearMocks: true,
   // An array of glob patterns indicating a set of files for which coverage information should be collected

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -671,6 +671,9 @@ export async function expectDifferentEtags(skylink1: string, skylink2: string): 
   // The skylinks should differ.
   expect(skylink1).not.toEqual(skylink2);
 
+  // Sleep for a bit to account for the portal's load balancer switching servers. This helps ensure that the uploaded files are available.
+  await new Promise((r) => setTimeout(r, 3000));
+
   // Download the files.
   let [url1, url2] = await Promise.all([client.getSkylinkUrl(skylink1), client.getSkylinkUrl(skylink2)]);
   const [response1, response2] = await Promise.all([


### PR DESCRIPTION
# PULL REQUEST

## Overview

Example test failure: https://github.com/SkynetLabs/skynet-js/pull/298/checks?check_run_id=3693225837