### PR TITLE
Accept root path seed in `deriveEncryptedPathSeed`

### DIFF
--- a/src/mysky/encrypted_files.test.ts
+++ b/src/mysky/encrypted_files.test.ts
@@ -77,7 +77,7 @@ describe("deriveEncryptedPathSeed", () => {
   });
 
   /**
-   * REGRESSION TEST
+   * Regression test:
    *
    * The issue was that `deriveEncryptedPathSeed` calculated path seeds of 64
    * bytes internally for each directory and then truncated to 32 bytes at the
@@ -100,9 +100,8 @@ describe("deriveEncryptedPathSeed", () => {
   });
 
   const filePathSeed = "a".repeat(64);
-  const filePathSeedError = "Expected parameter 'pathSeed' to be a directory path seed of length '128'";
-  const fullFilePathSeedError =
-    "Expected parameter 'pathSeed' to be a directory path seed of length '128', was type 'string', value 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'";
+  const filePathSeedError =
+    "Expected parameter 'pathSeed' to be a valid file or directory path seed of length '64' or '128'";
 
   // [pathSeed, subPath, isDirectory]
   const validTestCases: Array<[string, string, boolean]> = [
@@ -115,6 +114,9 @@ describe("deriveEncryptedPathSeed", () => {
     [rootPathSeed, "path/file.json/bar", false],
     [rootPathSeed, "path//to/file.json", true],
     [rootPathSeed, "path//to/file.json", false],
+    // should accept file path seeds
+    [filePathSeed, "path/to/file", true],
+    [filePathSeed, "path/to/file", false],
   ];
 
   it.each(validTestCases)("deriveEncryptedPathSeed(%s, %s, %s) should not throw", (pathSeed, subPath, isDirectory) => {
@@ -126,11 +128,6 @@ describe("deriveEncryptedPathSeed", () => {
     // should throw for an empty input sub path
     [rootPathSeed, "", true, "Input subPath '' not a valid path"],
     [rootPathSeed, "", false, "Input subPath '' not a valid path"],
-    // should not accept file path seeds
-    [filePathSeed, "path/to/file", true, fullFilePathSeedError],
-    [filePathSeed, "path/to/file", false, fullFilePathSeedError],
-    [filePathSeed, "", true, fullFilePathSeedError],
-    [filePathSeed, "", false, fullFilePathSeedError],
     // should not accept other non-directory path seeds
     ["b".repeat(63), "path/to/file", true, filePathSeedError],
     ["b".repeat(65), "path/to/file", false, filePathSeedError],

--- a/src/mysky/encrypted_files.ts
+++ b/src/mysky/encrypted_files.ts
@@ -232,13 +232,17 @@ export function deriveEncryptedPathSeed(pathSeed: string, subPath: string, isDir
   validateString("subPath", subPath, "parameter");
   validateBoolean("isDirectory", isDirectory, "parameter");
 
-  // The path seed must be for a directory and not a file.
-  if (pathSeed.length !== ENCRYPTION_PATH_SEED_DIRECTORY_LENGTH) {
+  // The path seed must be for a directory or a MySky root path seed.
+  //
+  // NOTE: As a historical artifact, the root path seed is the same length as a
+  // file path seed.
+  const acceptedLengths = [ENCRYPTION_PATH_SEED_FILE_LENGTH, ENCRYPTION_PATH_SEED_DIRECTORY_LENGTH];
+  if (!acceptedLengths.includes(pathSeed.length)) {
     throwValidationError(
       "pathSeed",
       pathSeed,
       "parameter",
-      `a directory path seed of length '${ENCRYPTION_PATH_SEED_DIRECTORY_LENGTH}'`
+      `a valid file or directory path seed of length '${ENCRYPTION_PATH_SEED_FILE_LENGTH}' or '${ENCRYPTION_PATH_SEED_DIRECTORY_LENGTH}'`
     );
   }
 


### PR DESCRIPTION


# PULL REQUEST

## Overview

MySky's root path seeds are still 32 bytes long, which we can't change or we
break compatibility:

https://github.com/SkynetLabs/skynet-mysky/blob/main/src/mysky.ts#L164

This commit removes a validation check so that the root
path seeds still work.

Integration tests pass with this new change:

https://github.com/SkynetLabs/test-skapp/pull/4