### PR TITLE
Fix a couple of bugs with tus concat

### DIFF
--- a/src/download.test.ts
+++ b/src/download.test.ts
@@ -304,7 +304,7 @@ describe("getFileContent", () => {
     expect(mock.history.get.length).toBe(1);
     const request = mock.history.get[0];
 
-    expect(request.headers["Range"]).toEqual(range);
+    expect(request.headers["range"]).toEqual(range);
   });
 
   it("should register onDownloadProgress callback if defined", async () => {

--- a/src/download.ts
+++ b/src/download.ts
@@ -581,7 +581,7 @@ export async function resolveHns(
 function buildGetFileContentHeaders(range?: string): Headers {
   const headers: Headers = {};
   if (range) {
-    headers["Range"] = range;
+    headers["range"] = range;
   }
   return headers;
 }

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -246,7 +246,7 @@ export async function uploadLargeFileRequest(
   });
 
   let parallelUploads = 1;
-  if (resp.headers["Tus-Extension"]?.contains("concatenation")) {
+  if (resp.headers["tus-extension"]?.includes("concatenation")) {
     parallelUploads = TUS_PARALLEL_UPLOADS;
   }
 


### PR DESCRIPTION


# PULL REQUEST

## Overview

There were a couple of bugs preventing tus concat from working.

- The header had to be lowercase.
- `contains` does not exist on strings.

Luckily, the crash from trying to call `contains` doesn't happen in production
because the capitalized header is never found.