### PR TITLE
Add `subdomain` opt to `executeRequest` + expose `executeRequest`

### DIFF
--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -23,13 +23,23 @@ describe("new SkynetClient", () => {
 });
 
 describe("buildRequestUrl", () => {
-  it("should build a URL from the given components", async () => {
-    const endpointPath = "/skynet/foo";
-    const extraPath = "bar";
-    const query = { foo: "bar" };
-    const expectedUrl = `${portalUrl}/skynet/foo/bar?foo=bar`;
+  const endpointPath = "/skynet/foo";
+  const subdomain = "account";
+  const extraPath = "bar";
+  const query = { foo: "bar" };
 
-    const url = await buildRequestUrl(client, endpointPath, undefined, extraPath, query);
+  it("should build a URL from the given components, using the override URL", async () => {
+    const overrideUrl = "siasky.dev";
+    const expectedUrl = `https://account.${overrideUrl}/skynet/foo/bar?foo=bar`;
+
+    const url = await buildRequestUrl(client, endpointPath, overrideUrl, subdomain, extraPath, query);
+    expect(url).toEqual(expectedUrl);
+  });
+
+  it("should build a URL from the given components, using the portal URL", async () => {
+    const expectedUrl = `https://account.siasky.net/skynet/foo/bar?foo=bar`;
+
+    const url = await buildRequestUrl(client, endpointPath, undefined, subdomain, extraPath, query);
     expect(url).toEqual(expectedUrl);
   });
 });

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -87,27 +87,25 @@ describe("buildRequestUrl", () => {
     const overrideUrl = "siasky.dev";
     const expectedUrl = `https://account.${overrideUrl}/skynet/foo/bar?foo=bar`;
 
-    const url = await buildRequestUrl(client, endpointPath, overrideUrl, subdomain, extraPath, query);
+    const url = await buildRequestUrl(client, { baseUrl: overrideUrl, endpointPath, subdomain, extraPath, query });
     expect(url).toEqual(expectedUrl);
   });
 
   it("should build a URL from the given components, using the portal URL", async () => {
     const expectedUrl = `https://account.siasky.net/skynet/foo/bar?foo=bar`;
 
-    const url = await buildRequestUrl(client, endpointPath, undefined, subdomain, extraPath, query);
+    const url = await buildRequestUrl(client, { endpointPath, subdomain, extraPath, query });
     expect(url).toEqual(expectedUrl);
   });
 
   describe("localhost inputs", () => {
-    const validExpectedLocalhosts = combineStrings(
-      ["https://", "https:", "http://", "http:"],
-      ["localhost"],
-      ["", "/"]
-    );
+    // `localhost` without a protocol prefix is not in this list because
+    // `buildRequestUrl` always ensures a prefix protocol for consistency.
+    const validExpectedLocalhosts = combineStrings(["https://", "http://"], ["localhost"], ["", "/"]);
     const localhostUrls = combineStrings(["", "https://", "https:", "http://", "http:"], ["localhost"], ["", "/"]);
 
     it.each(localhostUrls)("should correctly handle input '%s'", async (localhostUrl) => {
-      const url = await buildRequestUrl(client, undefined, localhostUrl);
+      const url = await buildRequestUrl(client, { baseUrl: localhostUrl });
       expect(validExpectedLocalhosts).toContainEqual(url);
     });
   });

--- a/src/client.ts
+++ b/src/client.ts
@@ -231,17 +231,13 @@ export class SkynetClient {
     return await SkynetClient.resolvedPortalUrl!; // eslint-disable-line
   }
 
-  // ===============
-  // Private Methods
-  // ===============
-
   /**
    * Creates and executes a request.
    *
    * @param config - Configuration for the request.
    * @returns - The response from axios.
    */
-  protected async executeRequest(config: RequestConfig): Promise<AxiosResponse> {
+  async executeRequest(config: RequestConfig): Promise<AxiosResponse> {
     const url = await buildRequestUrl(
       this,
       config.endpointPath,
@@ -296,8 +292,12 @@ export class SkynetClient {
     });
   }
 
+  // ===============
+  // Private Methods
+  // ===============
+
   /* istanbul ignore next */
-  async resolvePortalUrl(): Promise<string> {
+  protected async resolvePortalUrl(): Promise<string> {
     const response = await this.executeRequest({
       ...this.customOptions,
       method: "head",

--- a/src/download.ts
+++ b/src/download.ts
@@ -356,7 +356,6 @@ export async function getMetadata(
 
   const response = await this.executeRequest({
     ...opts,
-    endpointPath: opts.endpointGetMetadata,
     method: "GET",
     url,
   });
@@ -426,9 +425,10 @@ export async function getFileContentRequest(
   // GET request the data at the skylink.
   return await this.executeRequest({
     ...opts,
-    endpointPath: opts.endpointDownload,
     method: "get",
     url,
+    // Override the 'subdomain' option in the download options.
+    subdomain: undefined,
     headers,
   });
 }
@@ -460,10 +460,11 @@ export async function getFileContentHns<T = unknown>(
   const [response, { skylink: inputSkylink }] = await Promise.all([
     this.executeRequest({
       ...opts,
-      endpointPath: opts.endpointDownload,
       method: "get",
       url,
       headers,
+      // Override the 'subdomain' option in the download options.
+      subdomain: undefined,
     }),
     this.resolveHns(domain),
   ]);
@@ -550,7 +551,6 @@ export async function resolveHns(
   // Get the txt record from the hnsres domain on the portal.
   const response = await this.executeRequest({
     ...opts,
-    endpointPath: opts.endpointResolveHns,
     method: "get",
     url,
   });

--- a/src/mysky/utils.ts
+++ b/src/mysky/utils.ts
@@ -1,7 +1,5 @@
-import { ensureUrl } from "skynet-mysky-utils";
-
 import { SkynetClient } from "../client";
-import { getFullDomainUrlForPortal, extractDomainForPortal } from "../utils/url";
+import { getFullDomainUrlForPortal, extractDomainForPortal, ensureUrlPrefix } from "../utils/url";
 
 /**
  * Constructs the full URL for the given component domain,
@@ -47,7 +45,7 @@ export function popupCenter(url: string, winName: string, w: number, h: number):
     throw new Error("Current window is not valid");
   }
 
-  url = ensureUrl(url);
+  url = ensureUrlPrefix(url);
 
   const y = window.top.outerHeight / 2 + window.top.screenY - h / 2;
   const x = window.top.outerWidth / 2 + window.top.screenX - w / 2;

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -165,7 +165,6 @@ export async function getEntry(
   try {
     response = await this.executeRequest({
       ...opts,
-      endpointPath: opts.endpointGetEntry,
       url,
       method: "get",
       // Transform the response to add quotes, since uint64 cannot be accurately

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -219,7 +219,7 @@ export async function uploadLargeFileRequest(
   const opts = { ...DEFAULT_UPLOAD_OPTIONS, ...this.customOptions, ...customOptions };
 
   // TODO: Add back upload options once they are implemented in skyd.
-  const url = await buildRequestUrl(this, opts.endpointLargeUpload);
+  const url = await buildRequestUrl(this, { endpointPath: opts.endpointLargeUpload });
   const headers = buildRequestHeaders(undefined, opts.customUserAgent, opts.customCookie);
 
   file = ensureFileObjectConsistency(file);

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -74,7 +74,7 @@ export function trimSuffix(str: string, suffix: string, limit?: number): string 
  * Removes a URI prefix from the beginning of the string.
  *
  * @param str - The string to process.
- * @param prefix - The prefix to remove.
+ * @param prefix - The prefix to remove. Should contain double slashes, e.g. sia://.
  * @returns - The processed string.
  */
 export function trimUriPrefix(str: string, prefix: string): string {

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -94,6 +94,23 @@ export function addUrlQuery(url: string, query: { [key: string]: string | undefi
 }
 
 /**
+ * Ensures that the given string is a URL with a protocol prefix.
+ *
+ * @param url - The given string.
+ * @returns - The URL.
+ */
+export function ensureUrl(url: string): string {
+  if (url.startsWith("http:") || url.startsWith("https:")) {
+    return url;
+  }
+
+  if (url === "localhost") {
+    return "http://localhost/";
+  }
+  return `https://${url}`;
+}
+
+/**
  * Properly joins paths together to create a URL. Takes a variable number of
  * arguments.
  *

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,7 +1,7 @@
 import urljoin from "url-join";
 import parse from "url-parse";
 
-import { trimForwardSlash, trimSuffix, trimUriPrefix } from "./string";
+import { trimForwardSlash, trimPrefix, trimSuffix, trimUriPrefix } from "./string";
 import { throwValidationError, validateString } from "./validation";
 
 export const DEFAULT_SKYNET_PORTAL_URL = "https://siasky.net";
@@ -99,9 +99,15 @@ export function addUrlQuery(url: string, query: { [key: string]: string | undefi
  * @param url - The given string.
  * @returns - The URL.
  */
-export function ensureUrl(url: string): string {
-  if (url.startsWith("http:") || url.startsWith("https:")) {
+export function ensureUrlPrefix(url: string): string {
+  if (url.startsWith("http://") || url.startsWith("https://")) {
     return url;
+  }
+  if (url.startsWith("http:")) {
+    return `http://${trimPrefix(url, "http:")}`;
+  }
+  if (url.startsWith("https:")) {
+    return `https://${trimPrefix(url, "https:")}`;
   }
 
   if (url === "localhost") {


### PR DESCRIPTION
# PULL REQUEST

## Overview

- Makes some changes that were needed for MySky.
- Fixes a bug with portal URL resolution.
- Did a refactor.
- Added tests.

## Changelog

### Public changes

- Add `subdomain` opt to `executeRequest`.
  -  This was needed for MySky to access accounts at `account.<portal>`.
- Expose `executeRequest`.
  - This was `protected` as there were no known use cases for exposing it until now.
  - This is needed for MySky to implement requests to the challenge/response endpoints for accounts.
- Try resolving the portal URL again if the previous attempt failed.
  - Previously only a single request for the portal URL would ever be made 
  - (the `resolvedPortalUrl` promise was a static variable). 
  - Now we retry the request if it failed.

### Internal changes

- Refactor `buildRequestUrl`.
- Add some tests for resolving the portal URL, remove an istanbul.
- Add `ensureUrl`.
- Add some tests for properly-formed `localhost` URLs.