### PR TITLE
Another URL refactor for simplicity/consistency

### DIFF
--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -2,8 +2,8 @@ import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
 
 import { combineStrings } from "../utils/testing";
-import { buildRequestUrl } from "./client";
 import { SkynetClient } from "./index";
+import { buildRequestUrl } from "./request";
 import { defaultSkynetPortalUrl } from "./utils/url";
 
 const portalUrl = defaultSkynetPortalUrl;

--- a/src/client.ts
+++ b/src/client.ts
@@ -42,9 +42,10 @@ import {
   setEntryData,
   deleteEntryData,
 } from "./skydb";
-import { addUrlSubdomain, addUrlQuery, defaultPortalUrl, ensureUrlPrefix, makeUrl } from "./utils/url";
+import { defaultPortalUrl } from "./utils/url";
 import { loadMySky } from "./mysky";
 import { extractDomain, getFullDomainUrl } from "./mysky/utils";
+import { buildRequestHeaders, buildRequestUrl, Headers } from "./request";
 
 /**
  * Custom client options.
@@ -98,9 +99,13 @@ export type RequestConfig = CustomClientOptions & {
 export class SkynetClient {
   customOptions: CustomClientOptions;
 
-  // The initial portal URL, either given to `new SkynetClient()` or if not, the value of `defaultPortalUrl()`.
+  // The initial portal URL, the value of `defaultPortalUrl()` if `new
+  // SkynetClient` is called without a given portal. This initial URL is used to
+  // resolve the final portal URL.
   protected initialPortalUrl: string;
-  // The resolved API portal URL. The request won't be made until needed, or `initPortalUrl()` is called. The request is only made once, for all Skynet Clients.
+  // The resolved API portal URL. The request won't be made until needed, or
+  // `initPortalUrl()` is called. The request is only made once, for all Skynet
+  // Clients.
   protected static resolvedPortalUrl?: Promise<string>;
   // The custom portal URL, if one was passed in to `new SkynetClient()`.
   protected customPortalUrl?: string;
@@ -322,81 +327,4 @@ export class SkynetClient {
     }
     return portalUrl;
   }
-}
-
-// =======
-// Helpers
-// =======
-
-/**
- * Helper function that builds the request URL. Ensures that the final URL
- * always has a protocol prefix for consistency.
- *
- * @param client - The Skynet client.
- * @param parts - The URL parts to use when constructing the URL.
- * @param [parts.baseUrl] - The base URL to use, instead of the portal URL.
- * @param [parts.endpointPath] - The endpoint to contact.
- * @param [parts.subdomain] - An optional subdomain to add to the URL.
- * @param [parts.extraPath] - An optional path to append to the URL.
- * @param [parts.query] - Optional query parameters to append to the URL.
- * @returns - The built URL.
- */
-export async function buildRequestUrl(
-  client: SkynetClient,
-  parts: {
-    baseUrl?: string;
-    endpointPath?: string;
-    subdomain?: string;
-    extraPath?: string;
-    query?: { [key: string]: string | undefined };
-  }
-): Promise<string> {
-  let url;
-
-  // Get the base URL, if not passed in.
-  if (!parts.baseUrl) {
-    url = await client.portalUrl();
-  } else {
-    url = parts.baseUrl;
-  }
-
-  // Make sure the URL has a protocol.
-  url = ensureUrlPrefix(url);
-
-  if (parts.endpointPath) {
-    url = makeUrl(url, parts.endpointPath);
-  }
-  if (parts.extraPath) {
-    url = makeUrl(url, parts.extraPath);
-  }
-  if (parts.subdomain) {
-    url = addUrlSubdomain(url, parts.subdomain);
-  }
-  if (parts.query) {
-    url = addUrlQuery(url, parts.query);
-  }
-
-  return url;
-}
-
-export type Headers = { [key: string]: string };
-
-/**
- * Helper function that builds the request headers.
- *
- * @param [baseHeaders] - Any base headers.
- * @param [customUserAgent] - A custom user agent to set.
- * @param [customCookie] - A custom cookie.
- * @returns - The built headers.
- */
-export function buildRequestHeaders(baseHeaders?: Headers, customUserAgent?: string, customCookie?: string): Headers {
-  const returnHeaders = { ...baseHeaders };
-  // Set some headers from common options.
-  if (customUserAgent) {
-    returnHeaders["User-Agent"] = customUserAgent;
-  }
-  if (customCookie) {
-    returnHeaders["Cookie"] = customCookie;
-  }
-  return returnHeaders;
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -42,7 +42,7 @@ import {
   setEntryData,
   deleteEntryData,
 } from "./skydb";
-import { addSubdomain, addUrlQuery, defaultPortalUrl, ensureUrlPrefix, makeUrl } from "./utils/url";
+import { addUrlSubdomain, addUrlQuery, defaultPortalUrl, ensureUrlPrefix, makeUrl } from "./utils/url";
 import { loadMySky } from "./mysky";
 import { extractDomain, getFullDomainUrl } from "./mysky/utils";
 
@@ -370,7 +370,7 @@ export async function buildRequestUrl(
     url = makeUrl(url, parts.extraPath);
   }
   if (parts.subdomain) {
-    url = addSubdomain(url, parts.subdomain);
+    url = addUrlSubdomain(url, parts.subdomain);
   }
   if (parts.query) {
     url = addUrlQuery(url, parts.query);

--- a/src/download.ts
+++ b/src/download.ts
@@ -1,7 +1,8 @@
 import { AxiosResponse, ResponseType } from "axios";
 
-import { buildRequestUrl, Headers, SkynetClient } from "./client";
+import { SkynetClient } from "./client";
 import { getEntryLink, validateRegistryProof } from "./registry";
+import { buildRequestUrl, Headers } from "./request";
 import { convertSkylinkToBase32, formatSkylink } from "./skylink/format";
 import { parseSkylink } from "./skylink/parse";
 import { isSkylinkV1 } from "./skylink/sia";

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,0 +1,75 @@
+import { SkynetClient } from "./client";
+import { addUrlQuery, addUrlSubdomain, ensureUrlPrefix, makeUrl } from "./utils/url";
+
+export type Headers = { [key: string]: string };
+
+/**
+ * Helper function that builds the request headers.
+ *
+ * @param [baseHeaders] - Any base headers.
+ * @param [customUserAgent] - A custom user agent to set.
+ * @param [customCookie] - A custom cookie.
+ * @returns - The built headers.
+ */
+export function buildRequestHeaders(baseHeaders?: Headers, customUserAgent?: string, customCookie?: string): Headers {
+  const returnHeaders = { ...baseHeaders };
+  // Set some headers from common options.
+  if (customUserAgent) {
+    returnHeaders["User-Agent"] = customUserAgent;
+  }
+  if (customCookie) {
+    returnHeaders["Cookie"] = customCookie;
+  }
+  return returnHeaders;
+}
+
+/**
+ * Helper function that builds the request URL. Ensures that the final URL
+ * always has a protocol prefix for consistency.
+ *
+ * @param client - The Skynet client.
+ * @param parts - The URL parts to use when constructing the URL.
+ * @param [parts.baseUrl] - The base URL to use, instead of the portal URL.
+ * @param [parts.endpointPath] - The endpoint to contact.
+ * @param [parts.subdomain] - An optional subdomain to add to the URL.
+ * @param [parts.extraPath] - An optional path to append to the URL.
+ * @param [parts.query] - Optional query parameters to append to the URL.
+ * @returns - The built URL.
+ */
+export async function buildRequestUrl(
+  client: SkynetClient,
+  parts: {
+    baseUrl?: string;
+    endpointPath?: string;
+    subdomain?: string;
+    extraPath?: string;
+    query?: { [key: string]: string | undefined };
+  }
+): Promise<string> {
+  let url;
+
+  // Get the base URL, if not passed in.
+  if (!parts.baseUrl) {
+    url = await client.portalUrl();
+  } else {
+    url = parts.baseUrl;
+  }
+
+  // Make sure the URL has a protocol.
+  url = ensureUrlPrefix(url);
+
+  if (parts.endpointPath) {
+    url = makeUrl(url, parts.endpointPath);
+  }
+  if (parts.extraPath) {
+    url = makeUrl(url, parts.extraPath);
+  }
+  if (parts.subdomain) {
+    url = addUrlSubdomain(url, parts.subdomain);
+  }
+  if (parts.query) {
+    url = addUrlQuery(url, parts.query);
+  }
+
+  return url;
+}

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -4,9 +4,10 @@ import { HttpRequest, Upload } from "tus-js-client";
 import { getFileMimeType } from "./utils/file";
 import { BaseCustomOptions, DEFAULT_BASE_OPTIONS } from "./utils/options";
 import { formatSkylink } from "./skylink/format";
-import { buildRequestHeaders, buildRequestUrl, SkynetClient } from "./client";
+import { SkynetClient } from "./client";
 import { JsonData } from "./utils/types";
 import { throwValidationError, validateObject, validateOptionalObject, validateString } from "./utils/validation";
+import { buildRequestHeaders, buildRequestUrl } from "./request";
 
 /**
  * The tus chunk size is (4MiB - encryptionOverhead) * dataPieces, set in skyd.

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,5 +1,6 @@
 import mime from "mime/lite";
 import path from "path-browserify";
+
 import { trimPrefix } from "./string";
 
 /**

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -1,19 +1,46 @@
 import { combineStrings } from "../../utils/testing";
 import { trimPrefix, trimSuffix } from "./string";
-import { addUrlQuery, defaultSkynetPortalUrl, getFullDomainUrlForPortal, extractDomainForPortal, makeUrl } from "./url";
+import {
+  addUrlQuery,
+  defaultSkynetPortalUrl,
+  getFullDomainUrlForPortal,
+  extractDomainForPortal,
+  makeUrl,
+  addUrlSubdomain,
+} from "./url";
 
 const portalUrl = defaultSkynetPortalUrl;
 const skylink = "XABvi7JtJbQSMAcDwnUnmp2FKDPjg8_tTTFP4BwMSxVdEg";
 const skylinkBase32 = "bg06v2tidkir84hg0s1s4t97jaeoaa1jse1svrad657u070c9calq4g";
 
+describe("addUrlSubdomain", () => {
+  const parts: Array<[string, string, string]> = [
+    [portalUrl, "test", `https://test.siasky.net`],
+    [`${portalUrl}/`, "test", `https://test.siasky.net`],
+    [portalUrl, "foo.bar", `https://foo.bar.siasky.net`],
+    [`${portalUrl}/path`, "test", `https://test.siasky.net/path`],
+    [`${portalUrl}/path/`, "test", `https://test.siasky.net/path`],
+    [`${portalUrl}?foo=bar`, "test", `https://test.siasky.net/?foo=bar`],
+    [`${portalUrl}#foobar`, "test", `https://test.siasky.net/#foobar`],
+  ];
+
+  it.each(parts)(
+    "Should call addUrlSubdomain with URL %s and parameters %s and form URL %s",
+    (inputUrl, subdomain, expectedUrl) => {
+      const url = addUrlSubdomain(inputUrl, subdomain);
+      expect(url).toEqual(expectedUrl);
+    }
+  );
+});
+
 describe("addUrlQuery", () => {
   const parts: Array<[string, { [key: string]: string | undefined }, string]> = [
     [portalUrl, { filename: "test" }, `${portalUrl}/?filename=test`],
+    [`${portalUrl}/`, { attachment: "true" }, `${portalUrl}/?attachment=true`],
     [portalUrl, { attachment: "true" }, `${portalUrl}/?attachment=true`],
     [`${portalUrl}/path`, { download: "true" }, `${portalUrl}/path?download=true`],
     [`${portalUrl}/path/`, { download: "true" }, `${portalUrl}/path/?download=true`],
     [`${portalUrl}/skynet/`, { foo: "1", bar: "2" }, `${portalUrl}/skynet/?foo=1&bar=2`],
-    [`${portalUrl}/`, { attachment: "true" }, `${portalUrl}/?attachment=true`],
     [`${portalUrl}?foo=bar`, { attachment: "true" }, `${portalUrl}/?foo=bar&attachment=true`],
     [`${portalUrl}/?attachment=true`, { foo: "bar" }, `${portalUrl}/?attachment=true&foo=bar`],
     [`${portalUrl}#foobar`, { foo: "bar" }, `${portalUrl}/?foo=bar#foobar`],

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -71,7 +71,7 @@ export function addPath(url: string, path: string): string {
  * @param subdomain - The subdomain to add.
  * @returns - The final URL.
  */
-export function addSubdomain(url: string, subdomain: string): string {
+export function addUrlSubdomain(url: string, subdomain: string): string {
   const urlObj = new URL(url);
   urlObj.hostname = `${subdomain}.${urlObj.hostname}`;
   const str = urlObj.toString();
@@ -155,7 +155,7 @@ export function getFullDomainUrlForPortal(portalUrl: string, domain: string): st
     // Special handling for localhost.
     url = "localhost";
   } else {
-    url = addSubdomain(portalUrl, domain);
+    url = addUrlSubdomain(portalUrl, domain);
   }
   // Add back the path if there was one.
   if (path) {


### PR DESCRIPTION
# PULL REQUEST

## Overview

- Rename `addSubdomain` to `addUrlSubdomain` for consistency.
- Use `buildRequestUrl` in more places for simplicity.
- Add tests for `addUrlSubdomain`.
- Added `request.ts` file to move some logic out of `client.ts`, where it was causing circular dependencies and stuff not being defined at runtime.