### PR TITLE
[Breaking] Use `sign.detached` instead of `sign` to get just the signature

### DIFF
--- a/src/registry.ts
+++ b/src/registry.ts
@@ -430,7 +430,7 @@ export async function signEntry(
 
   // Sign the entry.
   // TODO: signature type should be Signature?
-  return sign(hashRegistryEntry(entry, hashedDataKeyHex), privateKeyArray);
+  return sign.detached(hashRegistryEntry(entry, hashedDataKeyHex), privateKeyArray);
 }
 
 /**


### PR DESCRIPTION
# PULL REQUEST

## Overview

Previously, the returned signature was longer than `SIGNATURE_LENGTH`. This is
because `sign` returns the signed message (including the original message) which
was not necessary -- we only need it to return the signature.

In addition to being unnecessary, it was also confusing to have a signature that
was longer than expected.

## Solution

We are now using `sign.detached`. We already use `verify.detached`.

This doesn't break the test suite because the extra bytes from `sign` 
were being just ignored. The return value for signature is now different though so we label it
a breaking change.