### PR TITLE
Get the full, descriptive error response returned from skyd

### DIFF
--- a/integration/skydb.test.ts
+++ b/integration/skydb.test.ts
@@ -1,6 +1,5 @@
-import { AxiosError } from "axios";
 import { client, dataKey, portal } from ".";
-import { genKeyPairAndSeed, getEntryLink, URI_SKYNET_PREFIX } from "../src";
+import { ExecuteRequestError, genKeyPairAndSeed, getEntryLink, URI_SKYNET_PREFIX } from "../src";
 import { hashDataKey } from "../src/crypto";
 import { decodeSkylinkBase64 } from "../src/utils/encoding";
 import { toHexString } from "../src/utils/string";
@@ -137,9 +136,9 @@ describe(`SkyDB end to end integration tests for portal '${portal}'`, () => {
     // TODO: Should getFileContent return `null` on 404?
     try {
       await client.getFileContent(entryLink);
-      throw new Error("getFileContent should not have succeeded");
+      throw new Error("'getFileContent' should not have succeeded");
     } catch (err) {
-      expect((err as AxiosError).response?.status).toEqual(404);
+      expect((err as ExecuteRequestError).responseStatus).toEqual(404);
     }
 
     // The SkyDB entry should be null.

--- a/integration/skydb.test.ts
+++ b/integration/skydb.test.ts
@@ -138,6 +138,8 @@ describe(`SkyDB end to end integration tests for portal '${portal}'`, () => {
       await client.getFileContent(entryLink);
       throw new Error("'getFileContent' should not have succeeded");
     } catch (err) {
+      // Assert the type and that instanceof behaves as expected.
+      expect(err).toBeInstanceOf(ExecuteRequestError);
       expect((err as ExecuteRequestError).responseStatus).toEqual(404);
     }
 

--- a/integration/upload_download.test.ts
+++ b/integration/upload_download.test.ts
@@ -246,6 +246,13 @@ describe(`Upload and download end-to-end tests for portal '${portal}'`, () => {
     expect(etag2).toBeTruthy();
     expect(etag2).not.toEqual(etag1);
   });
+
+  it("should fail to download a non-existent skylink", async () => {
+    // Use a resolver skylink as it will time out faster.
+    const skylink = "AQDwh1jnoZas9LaLHC_D4-2yO9XYDdZzNtz62H4Dww1jDB";
+
+    await expect(client.getFileContent(skylink)).rejects.toThrowError("Failed to resolve skylink");
+  });
 });
 
 /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { AxiosError } from "axios";
 import type { AxiosResponse, ResponseType, Method } from "axios";
 
 import {
@@ -45,6 +45,7 @@ import {
 import { addSubdomain, addUrlQuery, defaultPortalUrl, ensureUrlPrefix, makeUrl } from "./utils/url";
 import { loadMySky } from "./mysky";
 import { extractDomain, getFullDomainUrl } from "./mysky/utils";
+import { getPortalErrResponse } from "./request";
 
 /**
  * Custom client options.
@@ -244,6 +245,7 @@ export class SkynetClient {
    *
    * @param config - Configuration for the request.
    * @returns - The response from axios.
+   * @throws - Will throw if the request fails.
    */
   async executeRequest(config: RequestConfig): Promise<AxiosResponse> {
     const url = await buildRequestUrl(this, {
@@ -280,23 +282,27 @@ export class SkynetClient {
       };
     }
 
-    return axios({
-      url,
-      method: config.method,
-      data: config.data,
-      headers,
-      auth,
-      onDownloadProgress,
-      onUploadProgress,
-      responseType: config.responseType,
-      transformRequest: config.transformRequest,
-      transformResponse: config.transformResponse,
+    try {
+      return await axios({
+        url,
+        method: config.method,
+        data: config.data,
+        headers,
+        auth,
+        onDownloadProgress,
+        onUploadProgress,
+        responseType: config.responseType,
+        transformRequest: config.transformRequest,
+        transformResponse: config.transformResponse,
 
-      maxContentLength: Infinity,
-      maxBodyLength: Infinity,
-      // Allow cross-site cookies.
-      withCredentials: true,
-    });
+        maxContentLength: Infinity,
+        maxBodyLength: Infinity,
+        // Allow cross-site cookies.
+        withCredentials: true,
+      });
+    } catch (e) {
+      throw getPortalErrResponse(e as AxiosError);
+    }
   }
 
   // ===============

--- a/src/client.ts
+++ b/src/client.ts
@@ -245,7 +245,7 @@ export class SkynetClient {
    *
    * @param config - Configuration for the request.
    * @returns - The response from axios.
-   * @throws - Will throw if the request fails.
+   * @throws - Will throw `ExecuteRequestError` if the request fails. This error contains the original Axios error.
    */
   async executeRequest(config: RequestConfig): Promise<AxiosResponse> {
     const url = await buildRequestUrl(this, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,7 @@ export type {
   RegistryEntry,
   RegistryProofEntry,
 } from "./registry";
+export type { ExecuteRequestError } from "./request";
 export type {
   CustomGetJSONOptions,
   CustomSetJSONOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ export {
   deriveEncryptedFileSeed,
 } from "./mysky/encrypted_files";
 export { deriveDiscoverableFileTweak } from "./mysky/tweak";
+export { ExecuteRequestError } from "./request";
 export { DELETION_ENTRY_DATA } from "./skydb";
 export { convertSkylinkToBase32, convertSkylinkToBase64 } from "./skylink/format";
 export { parseSkylink } from "./skylink/parse";
@@ -82,7 +83,6 @@ export type {
   RegistryEntry,
   RegistryProofEntry,
 } from "./registry";
-export type { ExecuteRequestError } from "./request";
 export type {
   CustomGetJSONOptions,
   CustomSetJSONOptions,

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,8 +1,9 @@
-import type { AxiosError, AxiosResponse } from "axios";
+import type { AxiosResponse } from "axios";
 import { Buffer } from "buffer";
 import { sign } from "tweetnacl";
 
 import { SkynetClient } from "./client";
+import { ExecuteRequestError } from "./request";
 import { assertUint64 } from "./utils/number";
 import { BaseCustomOptions, DEFAULT_BASE_OPTIONS } from "./utils/options";
 import { ensurePrefix, hexToUint8Array, isHexString, toHexString, trimPrefix, trimUriPrefix } from "./utils/string";
@@ -185,7 +186,8 @@ export async function getEntry(
       },
     });
   } catch (err) {
-    return handleGetEntryErrResponse(err as AxiosError);
+    // Check the executeRequest error to see if a 404 status was returned.
+    return handleGetEntryErrResponse(err as ExecuteRequestError);
   }
 
   // Sanity check.
@@ -576,21 +578,13 @@ export function validateRegistryProof(
 /**
  * Handles error responses returned in getEntry.
  *
- * @param err - The Axios error.
+ * @param err - The error.
  * @returns - An empty signed registry entry if the status code is 404.
  * @throws - Will throw if the status code is not 404.
  */
-function handleGetEntryErrResponse(err: AxiosError): SignedRegistryEntry {
-  /* istanbul ignore next */
-  if (!err.response) {
-    throw new Error(`Error response field not found, incomplete Axios error. Full error: ${err}`);
-  }
-  /* istanbul ignore next */
-  if (!err.response.status) {
-    throw new Error(`Error response did not contain expected field 'status'. Full error: ${err}`);
-  }
+function handleGetEntryErrResponse(err: ExecuteRequestError): SignedRegistryEntry {
   // Check if status was 404 "not found" and return null if so.
-  if (err.response.status === 404) {
+  if (err.responseStatus === 404) {
     return { entry: null, signature: null };
   }
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -14,41 +14,46 @@ export class ExecuteRequestError extends Error {
     // Required for `instanceof` to work.
     Object.setPrototypeOf(this, ExecuteRequestError.prototype);
   }
-}
 
-/**
- * Gets the full, descriptive error response returned from skyd on the portal.
- *
- * @param err - The Axios error.
- * @returns - A new error if the error response is malformed, or the skyd error message otherwise.
- */
-export function getPortalErrResponse(err: AxiosError): ExecuteRequestError {
-  /* istanbul ignore next */
-  if (!err.response) {
-    return new ExecuteRequestError(`Error repsonse did not contain expected field 'response'.`, err, null, null);
-  }
-  /* istanbul ignore next */
-  if (!err.response.status) {
-    return new ExecuteRequestError(`Error response did not contain expected field 'response.status'.`, err, null, null);
-  }
+  /**
+   * Gets the full, descriptive error response returned from skyd on the portal.
+   *
+   * @param err - The Axios error.
+   * @returns - A new error if the error response is malformed, or the skyd error message otherwise.
+   */
+  static From(err: AxiosError): ExecuteRequestError {
+    /* istanbul ignore next */
+    if (!err.response) {
+      return new ExecuteRequestError(`Error repsonse did not contain expected field 'response'.`, err, null, null);
+    }
+    /* istanbul ignore next */
+    if (!err.response.status) {
+      return new ExecuteRequestError(
+        `Error response did not contain expected field 'response.status'.`,
+        err,
+        null,
+        null
+      );
+    }
 
-  const status = err.response.status;
+    const status = err.response.status;
 
-  // If we don't get an error message from skyd, just return the status code.
-  /* istanbul ignore next */
-  if (!err.response.data) {
-    return new ExecuteRequestError(`Request failed with status code ${status}.`, err, status, null);
-  }
-  /* istanbul ignore next */
-  if (!err.response.data.message) {
-    return new ExecuteRequestError(`Request failed with status code ${status}.`, err, status, null);
-  }
+    // If we don't get an error message from skyd, just return the status code.
+    /* istanbul ignore next */
+    if (!err.response.data) {
+      return new ExecuteRequestError(`Request failed with status code ${status}.`, err, status, null);
+    }
+    /* istanbul ignore next */
+    if (!err.response.data.message) {
+      return new ExecuteRequestError(`Request failed with status code ${status}.`, err, status, null);
+    }
 
-  // Return the error message from skyd. Pass along the original Axios error.
-  return new ExecuteRequestError(
-    `Request failed with status code ${err.response.status}: ${err.response.data.message}`,
-    err,
-    status,
-    err.response.data.message
-  );
+    // Return the error message from skyd. Pass along the original Axios error.
+    return new ExecuteRequestError(
+      `Request failed with status code ${err.response.status}: ${err.response.data.message}`,
+      err,
+      status,
+      err.response.data.message
+    );
+  }
 }

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,0 +1,54 @@
+import { AxiosError } from "axios";
+
+export class ExecuteRequestError extends Error {
+  originalError: AxiosError;
+  responseStatus: number | null;
+  responseMessage: string | null;
+
+  constructor(message: string, axiosError: AxiosError, responseStatus: number | null, responseMessage: string | null) {
+    super(message);
+    this.originalError = axiosError;
+    this.responseStatus = responseStatus;
+    this.responseMessage = responseMessage;
+
+    // Required for `instanceof` to work.
+    Object.setPrototypeOf(this, ExecuteRequestError.prototype);
+  }
+}
+
+/**
+ * Gets the full, descriptive error response returned from skyd on the portal.
+ *
+ * @param err - The Axios error.
+ * @returns - A new error if the error response is malformed, or the skyd error message otherwise.
+ */
+export function getPortalErrResponse(err: AxiosError): ExecuteRequestError {
+  /* istanbul ignore next */
+  if (!err.response) {
+    return new ExecuteRequestError(`Error repsonse did not contain expected field 'response'.`, err, null, null);
+  }
+  /* istanbul ignore next */
+  if (!err.response.status) {
+    return new ExecuteRequestError(`Error response did not contain expected field 'response.status'.`, err, null, null);
+  }
+
+  const status = err.response.status;
+
+  // If we don't get an error message from skyd, just return the status code.
+  /* istanbul ignore next */
+  if (!err.response.data) {
+    return new ExecuteRequestError(`Request failed with status code ${status}.`, err, status, null);
+  }
+  /* istanbul ignore next */
+  if (!err.response.data.message) {
+    return new ExecuteRequestError(`Request failed with status code ${status}.`, err, status, null);
+  }
+
+  // Return the error message from skyd. Pass along the original Axios error.
+  return new ExecuteRequestError(
+    `Request failed with status code ${err.response.status}: ${err.response.data.message}`,
+    err,
+    status,
+    err.response.data.message
+  );
+}

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -280,14 +280,18 @@ export async function uploadLargeFileRequest(
         }
 
         // Call HEAD to get the metadata, including the skylink.
-        const resp = await this.executeRequest({
-          ...opts,
-          url: upload.url,
-          endpointPath: opts.endpointLargeUpload,
-          method: "head",
-          headers: { ...headers, "Tus-Resumable": "1.0.0" },
-        });
-        resolve(resp);
+        try {
+          const resp = await this.executeRequest({
+            ...opts,
+            url: upload.url,
+            endpointPath: opts.endpointLargeUpload,
+            method: "head",
+            headers: { ...headers, "Tus-Resumable": "1.0.0" },
+          });
+          resolve(resp);
+        } catch (err) {
+          reject(err);
+        }
       },
     };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1265,9 +1265,9 @@ camelcase@^6.0.0:
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-lite@^1.0.30001219:
-  version "1.0.30001235"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001235.tgz#ad5ca75bc5a1f7b12df79ad806d715a43a5ac4ed"
-  integrity sha512-zWEwIVqnzPkSAXOUlQnPW2oKoYb2aLQ4Q5ejdjBcnH63rfypaW34CxaeBn1VMya2XaEU3P/R2qHpWyj+l0BT1A==
+  version "1.0.30001286"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001286.tgz"
+  integrity sha512-zaEMRH6xg8ESMi2eQ3R4eZ5qw/hJiVsO/HlLwniIwErij0JDr9P+8V4dtx1l+kLq6j3yy8l8W4fst1lBnat5wQ==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
# PULL REQUEST

## Overview

Previously, methods were returning error messages that said e.g. "Request failed
with status code 429" and we had to drill down into the actual response to see
what the skyd error was.

All methods that make a request now return a descriptive error message based on
the skyd response message.

- Added `ExecuteRequestError` which contains the original Axios error. We now 
  throw this on network errors instead of `AxiosError` directly.

- Added `request.ts` file for ExecuteRequestError. I originally tried putting it in 
 `client.ts` where it was causing circular dependencies and stuff not being defined
  at runtime.

- Also, I fixed a bug where a promise in `uploadLargeFile` was not being
  rejected on error.

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [ ] Changelog file created
