### PR TITLE
Export missing encryption utilities

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,9 +25,12 @@ export {
   mySkyDomain,
 } from "./mysky";
 export {
+  decryptJSONFile,
   deriveEncryptedFileKeyEntropy,
   deriveEncryptedFileTweak,
   deriveEncryptedPathSeed,
+  encryptJSONFile,
+  ENCRYPTED_JSON_RESPONSE_VERSION,
   ENCRYPTION_PATH_SEED_DIRECTORY_LENGTH,
   ENCRYPTION_PATH_SEED_FILE_LENGTH,
   // Deprecated.
@@ -74,6 +77,7 @@ export type { CustomClientOptions, RequestConfig } from "./client";
 export type { KeyPair, KeyPairAndSeed, Signature } from "./crypto";
 export type { CustomDownloadOptions, ResolveHnsResponse } from "./download";
 export type { CustomConnectorOptions, EntryData } from "./mysky";
+export type { EncryptedJSONResponse } from "./mysky/encrypted_files";
 export type { CustomPinOptions, PinResponse } from "./pin";
 export type {
   CustomGetEntryOptions,


### PR DESCRIPTION
# PULL REQUEST

## Overview

Export some encryption utilities that are needed for MySky to be able to call its own set/getJSONEncrypted (needed for getting preferred portal & stored email for autologin).

## Notes

There are a lot of exports in the skynet-js namespace, and I do plan to clean up the exports at some point by additionally namespacing them. I'll do that before we release a stable v4.