### PR TITLE
Fix broken large uploads (tus 491 error)

### DIFF
--- a/src/upload.ts
+++ b/src/upload.ts
@@ -304,7 +304,6 @@ export async function uploadLargeFileRequest(
           const resp = await this.executeRequest({
             ...opts,
             url: upload.url,
-            endpointPath: opts.endpointLargeUpload,
             method: "head",
             headers: { ...headers, "tus-resumable": "1.0.0" },
           });


### PR DESCRIPTION
# PULL REQUEST

## Overview

Large uploads were failing with a `491` error. This is because of the refactor that changed how URLs are built. The `head` request to get the final metadata of the tus upload was missed in the refactor, and an extraneous

```ts
endpointPath: opts.endpointLargeUpload,
```

was resulting in URLs of the form

```
https://us-va-1.siasky.net/skynet/tus/24581d62dba2a045935680a9c41b0d1b3cd50538/skynet/tus
```

(Note the extra `/skynet/tus` at the end.)

## Testing

These changes are deployed at:

https://siasky.net/_Aw17anCbXiagDVXQaDktW1m5WuV4FB-S2bk2YdzNM2WZg

(Ignore all the stuff except for the upload form at the top.)