### PR TITLE
[NEEDS TESTING] Add option for portal API keys and env var for integration tests

### DIFF
--- a/integration/index.ts
+++ b/integration/index.ts
@@ -13,8 +13,8 @@ export const portal = process.env.SKYNET_JS_INTEGRATION_TEST_SERVER || DEFAULT_S
 //
 // Example:
 //
-// SKYNET_JS_INTEGRATION_TEST_API_KEY_PORTAL=foo yarn run jest integration
-export const APIKeyPortal = process.env.SKYNET_JS_INTEGRATION_TEST_API_KEY_PORTAL;
+// SKYNET_JS_INTEGRATION_TEST_SKYNET_API_KEY_PORTAL=foo yarn run jest integration
+export const skynetAPIKey = process.env.SKYNET_JS_INTEGRATION_TEST_SKYNET_API_KEY;
 // Allow setting custom cookies.
 //
 // Example:
@@ -22,7 +22,7 @@ export const APIKeyPortal = process.env.SKYNET_JS_INTEGRATION_TEST_API_KEY_PORTA
 // SKYNET_JS_INTEGRATION_TEST_CUSTOM_COOKIE=skynet-jwt=foo yarn run jest integration
 export const customCookie = process.env.SKYNET_JS_INTEGRATION_TEST_CUSTOM_COOKIE;
 
-export const client = new SkynetClient(portal, { APIKeyPortal, customCookie });
+export const client = new SkynetClient(portal, { skynetAPIKey, customCookie });
 
 export const dataKey = "HelloWorld";
 

--- a/integration/index.ts
+++ b/integration/index.ts
@@ -9,14 +9,20 @@ import { trimPrefix } from "../src/utils/string";
 //
 // SKYNET_JS_INTEGRATION_TEST_SERVER=https://eu-fin-1.siasky.net yarn run jest integration
 export const portal = process.env.SKYNET_JS_INTEGRATION_TEST_SERVER || DEFAULT_SKYNET_PORTAL_URL;
-// Allow setting custom cookies for e.g. authentication for running tests on paid portals.
+// Allow setting a custom API key for e.g. authentication for running tests on paid portals.
+//
+// Example:
+//
+// SKYNET_JS_INTEGRATION_TEST_API_KEY_PORTAL=foo yarn run jest integration
+export const APIKeyPortal = process.env.SKYNET_JS_INTEGRATION_TEST_API_KEY_PORTAL;
+// Allow setting custom cookies.
 //
 // Example:
 //
 // SKYNET_JS_INTEGRATION_TEST_CUSTOM_COOKIE=skynet-jwt=foo yarn run jest integration
-export const customCookie = process.env.SKYNET_JS_INTEGRATION_TEST_CUSTOM_COOKIE || undefined;
+export const customCookie = process.env.SKYNET_JS_INTEGRATION_TEST_CUSTOM_COOKIE;
 
-export const client = new SkynetClient(portal, { customCookie });
+export const client = new SkynetClient(portal, { APIKeyPortal, customCookie });
 
 export const dataKey = "HelloWorld";
 

--- a/integration/index.ts
+++ b/integration/index.ts
@@ -13,7 +13,7 @@ export const portal = process.env.SKYNET_JS_INTEGRATION_TEST_SERVER || DEFAULT_S
 //
 // Example:
 //
-// SKYNET_JS_INTEGRATION_TEST_SKYNET_API_KEY_PORTAL=foo yarn run jest integration
+// SKYNET_JS_INTEGRATION_TEST_SKYNET_API_KEY=foo yarn run jest integration
 export const skynetApiKey = process.env.SKYNET_JS_INTEGRATION_TEST_SKYNET_API_KEY;
 // Allow setting custom cookies.
 //

--- a/integration/index.ts
+++ b/integration/index.ts
@@ -14,7 +14,7 @@ export const portal = process.env.SKYNET_JS_INTEGRATION_TEST_SERVER || DEFAULT_S
 // Example:
 //
 // SKYNET_JS_INTEGRATION_TEST_SKYNET_API_KEY_PORTAL=foo yarn run jest integration
-export const skynetAPIKey = process.env.SKYNET_JS_INTEGRATION_TEST_SKYNET_API_KEY;
+export const skynetApiKey = process.env.SKYNET_JS_INTEGRATION_TEST_SKYNET_API_KEY;
 // Allow setting custom cookies.
 //
 // Example:
@@ -22,7 +22,7 @@ export const skynetAPIKey = process.env.SKYNET_JS_INTEGRATION_TEST_SKYNET_API_KE
 // SKYNET_JS_INTEGRATION_TEST_CUSTOM_COOKIE=skynet-jwt=foo yarn run jest integration
 export const customCookie = process.env.SKYNET_JS_INTEGRATION_TEST_CUSTOM_COOKIE;
 
-export const client = new SkynetClient(portal, { skynetAPIKey, customCookie });
+export const client = new SkynetClient(portal, { skynetApiKey, customCookie });
 
 export const dataKey = "HelloWorld";
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -394,7 +394,7 @@ export type Headers = { [key: string]: string };
  * @param [baseHeaders] - Any base headers.
  * @param [customUserAgent] - A custom user agent to set.
  * @param [customCookie] - A custom cookie.
- * @param [skynetApiKey] - Authentication password to use for a Skynet portal.
+ * @param [skynetApiKey] - Authentication key to use for a Skynet portal.
  * @returns - The built headers.
  */
 export function buildRequestHeaders(

--- a/src/client.ts
+++ b/src/client.ts
@@ -49,7 +49,8 @@ import { extractDomain, getFullDomainUrl } from "./mysky/utils";
 /**
  * Custom client options.
  *
- * @property [APIKey] - Authentication password to use.
+ * @property [APIKey] - Authentication password to use for a single Skynet node.
+ * @property [APIKeyPortal] - Authentication password to use for a Skynet portal.
  * @property [customUserAgent] - Custom user agent header to set.
  * @property [customCookie] - Custom cookie header to set. WARNING: the Cookie header cannot be set in browsers. This is meant for usage in server contexts.
  * @property [onDownloadProgress] - Optional callback to track download progress.
@@ -57,6 +58,7 @@ import { extractDomain, getFullDomainUrl } from "./mysky/utils";
  */
 export type CustomClientOptions = {
   APIKey?: string;
+  APIKeyPortal?: string;
   customUserAgent?: string;
   customCookie?: string;
   onDownloadProgress?: (progress: number, event: ProgressEvent) => void;
@@ -255,7 +257,12 @@ export class SkynetClient {
     });
 
     // Build headers.
-    const headers = buildRequestHeaders(config.headers, config.customUserAgent, config.customCookie);
+    const headers = buildRequestHeaders(
+      config.headers,
+      config.customUserAgent,
+      config.customCookie,
+      config.APIKeyPortal
+    );
 
     const auth = config.APIKey ? { username: "", password: config.APIKey } : undefined;
 
@@ -387,9 +394,15 @@ export type Headers = { [key: string]: string };
  * @param [baseHeaders] - Any base headers.
  * @param [customUserAgent] - A custom user agent to set.
  * @param [customCookie] - A custom cookie.
+ * @param [APIKeyPortal] - Authentication password to use for a Skynet portal.
  * @returns - The built headers.
  */
-export function buildRequestHeaders(baseHeaders?: Headers, customUserAgent?: string, customCookie?: string): Headers {
+export function buildRequestHeaders(
+  baseHeaders?: Headers,
+  customUserAgent?: string,
+  customCookie?: string,
+  APIKeyPortal?: string
+): Headers {
   const returnHeaders = { ...baseHeaders };
   // Set some headers from common options.
   if (customUserAgent) {
@@ -397,6 +410,9 @@ export function buildRequestHeaders(baseHeaders?: Headers, customUserAgent?: str
   }
   if (customCookie) {
     returnHeaders["Cookie"] = customCookie;
+  }
+  if (APIKeyPortal) {
+    returnHeaders["Authorization"] = `Bearer ${APIKeyPortal}`;
   }
   return returnHeaders;
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -50,7 +50,7 @@ import { extractDomain, getFullDomainUrl } from "./mysky/utils";
  * Custom client options.
  *
  * @property [APIKey] - Authentication password to use for a single Skynet node.
- * @property [skynetAPIKey] - Authentication API key to use for a Skynet portal (sets the "Skynet-API-Key" header).
+ * @property [skynetApiKey] - Authentication API key to use for a Skynet portal (sets the "Skynet-Api-Key" header).
  * @property [customUserAgent] - Custom user agent header to set.
  * @property [customCookie] - Custom cookie header to set. WARNING: the Cookie header cannot be set in browsers. This is meant for usage in server contexts.
  * @property [onDownloadProgress] - Optional callback to track download progress.
@@ -58,7 +58,7 @@ import { extractDomain, getFullDomainUrl } from "./mysky/utils";
  */
 export type CustomClientOptions = {
   APIKey?: string;
-  skynetAPIKey?: string;
+  skynetApiKey?: string;
   customUserAgent?: string;
   customCookie?: string;
   onDownloadProgress?: (progress: number, event: ProgressEvent) => void;
@@ -261,7 +261,7 @@ export class SkynetClient {
       config.headers,
       config.customUserAgent,
       config.customCookie,
-      config.skynetAPIKey
+      config.skynetApiKey
     );
 
     const auth = config.APIKey ? { username: "", password: config.APIKey } : undefined;
@@ -394,14 +394,14 @@ export type Headers = { [key: string]: string };
  * @param [baseHeaders] - Any base headers.
  * @param [customUserAgent] - A custom user agent to set.
  * @param [customCookie] - A custom cookie.
- * @param [skynetAPIKey] - Authentication password to use for a Skynet portal.
+ * @param [skynetApiKey] - Authentication password to use for a Skynet portal.
  * @returns - The built headers.
  */
 export function buildRequestHeaders(
   baseHeaders?: Headers,
   customUserAgent?: string,
   customCookie?: string,
-  skynetAPIKey?: string
+  skynetApiKey?: string
 ): Headers {
   const returnHeaders = { ...baseHeaders };
   // Set some headers from common options.
@@ -411,8 +411,8 @@ export function buildRequestHeaders(
   if (customCookie) {
     returnHeaders["Cookie"] = customCookie;
   }
-  if (skynetAPIKey) {
-    returnHeaders["Skynet-API-Key"] = skynetAPIKey;
+  if (skynetApiKey) {
+    returnHeaders["Skynet-Api-Key"] = skynetApiKey;
   }
   return returnHeaders;
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -50,7 +50,7 @@ import { extractDomain, getFullDomainUrl } from "./mysky/utils";
  * Custom client options.
  *
  * @property [APIKey] - Authentication password to use for a single Skynet node.
- * @property [APIKeyPortal] - Authentication password to use for a Skynet portal.
+ * @property [skynetAPIKey] - Authentication API key to use for a Skynet portal (sets the "Skynet-API-Key" header).
  * @property [customUserAgent] - Custom user agent header to set.
  * @property [customCookie] - Custom cookie header to set. WARNING: the Cookie header cannot be set in browsers. This is meant for usage in server contexts.
  * @property [onDownloadProgress] - Optional callback to track download progress.
@@ -58,7 +58,7 @@ import { extractDomain, getFullDomainUrl } from "./mysky/utils";
  */
 export type CustomClientOptions = {
   APIKey?: string;
-  APIKeyPortal?: string;
+  skynetAPIKey?: string;
   customUserAgent?: string;
   customCookie?: string;
   onDownloadProgress?: (progress: number, event: ProgressEvent) => void;
@@ -261,7 +261,7 @@ export class SkynetClient {
       config.headers,
       config.customUserAgent,
       config.customCookie,
-      config.APIKeyPortal
+      config.skynetAPIKey
     );
 
     const auth = config.APIKey ? { username: "", password: config.APIKey } : undefined;
@@ -394,14 +394,14 @@ export type Headers = { [key: string]: string };
  * @param [baseHeaders] - Any base headers.
  * @param [customUserAgent] - A custom user agent to set.
  * @param [customCookie] - A custom cookie.
- * @param [APIKeyPortal] - Authentication password to use for a Skynet portal.
+ * @param [skynetAPIKey] - Authentication password to use for a Skynet portal.
  * @returns - The built headers.
  */
 export function buildRequestHeaders(
   baseHeaders?: Headers,
   customUserAgent?: string,
   customCookie?: string,
-  APIKeyPortal?: string
+  skynetAPIKey?: string
 ): Headers {
   const returnHeaders = { ...baseHeaders };
   // Set some headers from common options.
@@ -411,8 +411,8 @@ export function buildRequestHeaders(
   if (customCookie) {
     returnHeaders["Cookie"] = customCookie;
   }
-  if (APIKeyPortal) {
-    returnHeaders["Authorization"] = `Bearer ${APIKeyPortal}`;
+  if (skynetAPIKey) {
+    returnHeaders["Skynet-API-Key"] = skynetAPIKey;
   }
   return returnHeaders;
 }

--- a/src/upload.test.ts
+++ b/src/upload.test.ts
@@ -75,13 +75,13 @@ describe("uploadFile", () => {
   });
 
   it("should send base-64 authentication password if provided", async () => {
-    const data = await client.uploadFile(file, { APIKey: "foo", skynetAPIKey: "bar" });
+    const data = await client.uploadFile(file, { APIKey: "foo", skynetApiKey: "bar" });
 
     expect(mock.history.post.length).toBe(1);
     const request = mock.history.post[0];
 
     expect(request.auth).toEqual({ username: "", password: "foo" });
-    expect(request.headers).toEqual(expect.objectContaining({ "Skynet-API-Key": "bar" }));
+    expect(request.headers).toEqual(expect.objectContaining({ "Skynet-Api-Key": "bar" }));
     await compareFormData(request.data, [["file", "foo", filename]]);
 
     expect(data.skylink).toEqual(sialink);

--- a/src/upload.test.ts
+++ b/src/upload.test.ts
@@ -75,12 +75,13 @@ describe("uploadFile", () => {
   });
 
   it("should send base-64 authentication password if provided", async () => {
-    const data = await client.uploadFile(file, { APIKey: "foobar" });
+    const data = await client.uploadFile(file, { APIKey: "foo", APIKeyPortal: "bar" });
 
     expect(mock.history.post.length).toBe(1);
     const request = mock.history.post[0];
 
-    expect(request.auth).toEqual({ username: "", password: "foobar" });
+    expect(request.auth).toEqual({ username: "", password: "foo" });
+    expect(request.headers).toEqual(expect.objectContaining({ Authorization: "Bearer bar" }));
     await compareFormData(request.data, [["file", "foo", filename]]);
 
     expect(data.skylink).toEqual(sialink);

--- a/src/upload.test.ts
+++ b/src/upload.test.ts
@@ -75,13 +75,13 @@ describe("uploadFile", () => {
   });
 
   it("should send base-64 authentication password if provided", async () => {
-    const data = await client.uploadFile(file, { APIKey: "foo", APIKeyPortal: "bar" });
+    const data = await client.uploadFile(file, { APIKey: "foo", skynetAPIKey: "bar" });
 
     expect(mock.history.post.length).toBe(1);
     const request = mock.history.post[0];
 
     expect(request.auth).toEqual({ username: "", password: "foo" });
-    expect(request.headers).toEqual(expect.objectContaining({ Authorization: "Bearer bar" }));
+    expect(request.headers).toEqual(expect.objectContaining({ "Skynet-API-Key": "bar" }));
     await compareFormData(request.data, [["file", "foo", filename]]);
 
     expect(data.skylink).toEqual(sialink);

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -220,7 +220,7 @@ export async function uploadLargeFileRequest(
 
   // TODO: Add back upload options once they are implemented in skyd.
   const url = await buildRequestUrl(this, { endpointPath: opts.endpointLargeUpload });
-  const headers = buildRequestHeaders(undefined, opts.customUserAgent, opts.customCookie);
+  const headers = buildRequestHeaders(undefined, opts.customUserAgent, opts.customCookie, opts.APIKeyPortal);
 
   file = ensureFileObjectConsistency(file);
   let filename = file.name;

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -220,7 +220,7 @@ export async function uploadLargeFileRequest(
 
   // TODO: Add back upload options once they are implemented in skyd.
   const url = await buildRequestUrl(this, { endpointPath: opts.endpointLargeUpload });
-  const headers = buildRequestHeaders(undefined, opts.customUserAgent, opts.customCookie, opts.APIKeyPortal);
+  const headers = buildRequestHeaders(undefined, opts.customUserAgent, opts.customCookie, opts.skynetAPIKey);
 
   file = ensureFileObjectConsistency(file);
   let filename = file.name;

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -220,7 +220,7 @@ export async function uploadLargeFileRequest(
 
   // TODO: Add back upload options once they are implemented in skyd.
   const url = await buildRequestUrl(this, { endpointPath: opts.endpointLargeUpload });
-  const headers = buildRequestHeaders(undefined, opts.customUserAgent, opts.customCookie, opts.skynetAPIKey);
+  const headers = buildRequestHeaders(undefined, opts.customUserAgent, opts.customCookie, opts.skynetApiKey);
 
   file = ensureFileObjectConsistency(file);
   let filename = file.name;

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -10,6 +10,7 @@ export type BaseCustomOptions = CustomClientOptions;
  */
 export const DEFAULT_BASE_OPTIONS = {
   APIKey: "",
+  APIKeyPortal: "",
   customUserAgent: "",
   customCookie: "",
   onDownloadProgress: undefined,

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -10,7 +10,7 @@ export type BaseCustomOptions = CustomClientOptions;
  */
 export const DEFAULT_BASE_OPTIONS = {
   APIKey: "",
-  skynetAPIKey: "",
+  skynetApiKey: "",
   customUserAgent: "",
   customCookie: "",
   onDownloadProgress: undefined,

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -10,7 +10,7 @@ export type BaseCustomOptions = CustomClientOptions;
  */
 export const DEFAULT_BASE_OPTIONS = {
   APIKey: "",
-  APIKeyPortal: "",
+  skynetAPIKey: "",
   customUserAgent: "",
   customCookie: "",
   onDownloadProgress: undefined,


### PR DESCRIPTION
# PULL REQUEST

## Overview

Needed to be able to run integration tests against the new pro portal.

Going to merge this into the newly-created `beta` branch, as there are changes in `master` that are not ready for a version publish.