### PR TITLE
Don't throw if portal redirect fails

### DIFF
--- a/src/mysky/index.ts
+++ b/src/mysky/index.ts
@@ -206,19 +206,20 @@ export class MySky {
 
     // Redirect if we're not on the preferred portal. See
     // `redirectIfNotOnPreferredPortal` for full load flow.
-    try {
-      // TODO: Uncomment the below line once autologin is released. Otherwise
-      // the dev console will be spammed with unactionable warnings.
-      // await MySky.instance.redirectIfNotOnPreferredPortal();
-    } catch (e) {
-      // Don't throw an error if we couldn't redirect. The user will never be
-      // able to log in to MySky and change his preferred portal if MySky can't
-      // load.
-      //
-      // TODO: Add some infrastructure to return warnings to the skapp instead
-      // of errors?
-      console.warn(e);
-    }
+    //
+    // TODO: Uncomment the below line once autologin is released. Otherwise the
+    // dev console will be spammed with unactionable warnings.
+    // try {
+    //   await MySky.instance.redirectIfNotOnPreferredPortal();
+    // } catch (e) {
+    //   // Don't throw an error if we couldn't redirect. The user will never be
+    //   // able to log in to MySky and change his preferred portal if MySky can't
+    //   // load.
+    //   //
+    //   // TODO: Add some infrastructure to return warnings to the skapp instead
+    //   // of errors?
+    //   console.warn(e);
+    // }
 
     return MySky.instance;
   }
@@ -623,23 +624,24 @@ export class MySky {
 
     // Redirect if we're not on the preferred portal. See
     // `redirectIfNotOnPreferredPortal` for full login flow.
-    try {
-      // TODO: Uncomment the below line once autologin is released. Otherwise
-      // the dev console will be spammed with unactionable warnings.
-      // await this.redirectIfNotOnPreferredPortal();
-      // // If we can log in to the portal account, set up auto-relogin.
-      // if (await this.checkPortalLogin()) {
-      //   this.connector.client.customOptions.loginFn = this.portalLogin;
-      // }
-    } catch (e) {
-      // Don't throw an error if we couldn't redirect. The user will never be
-      // able to log in to MySky and change his preferred portal if MySky can't
-      // load.
-      //
-      // TODO: Add some infrastructure to return warnings to the skapp instead
-      // of errors?
-      console.warn(e);
-    }
+    //
+    // TODO: Uncomment the below line once autologin is released. Otherwise the
+    // dev console will be spammed with unactionable warnings.
+    // try {
+    //   await this.redirectIfNotOnPreferredPortal();
+    //   // If we can log in to the portal account, set up auto-relogin.
+    //   if (await this.checkPortalLogin()) {
+    //     this.connector.client.customOptions.loginFn = this.portalLogin;
+    //   }
+    // } catch (e) {
+    //   // Don't throw an error if we couldn't redirect. The user will never be
+    //   // able to log in to MySky and change his preferred portal if MySky can't
+    //   // load.
+    //   //
+    //   // TODO: Add some infrastructure to return warnings to the skapp instead
+    //   // of errors?
+    //   console.warn(e);
+    // }
   }
 
   /**

--- a/src/mysky/index.ts
+++ b/src/mysky/index.ts
@@ -206,7 +206,19 @@ export class MySky {
 
     // Redirect if we're not on the preferred portal. See
     // `redirectIfNotOnPreferredPortal` for full load flow.
-    await MySky.instance.redirectIfNotOnPreferredPortal();
+    try {
+      // TODO: Uncomment the below line once autologin is released. Otherwise
+      // the dev console will be spammed with unactionable warnings.
+      // await MySky.instance.redirectIfNotOnPreferredPortal();
+    } catch (e) {
+      // Don't throw an error if we couldn't redirect. The user will never be
+      // able to log in to MySky and change his preferred portal if MySky can't
+      // load.
+      //
+      // TODO: Add some infrastructure to return warnings to the skapp instead
+      // of errors?
+      console.warn(e);
+    }
 
     return MySky.instance;
   }
@@ -611,11 +623,22 @@ export class MySky {
 
     // Redirect if we're not on the preferred portal. See
     // `redirectIfNotOnPreferredPortal` for full login flow.
-    await this.redirectIfNotOnPreferredPortal();
-
-    // If we can log in to the portal account, set up auto-relogin.
-    if (await this.checkPortalLogin()) {
-      this.connector.client.customOptions.loginFn = this.portalLogin;
+    try {
+      // TODO: Uncomment the below line once autologin is released. Otherwise
+      // the dev console will be spammed with unactionable warnings.
+      // await this.redirectIfNotOnPreferredPortal();
+      // // If we can log in to the portal account, set up auto-relogin.
+      // if (await this.checkPortalLogin()) {
+      //   this.connector.client.customOptions.loginFn = this.portalLogin;
+      // }
+    } catch (e) {
+      // Don't throw an error if we couldn't redirect. The user will never be
+      // able to log in to MySky and change his preferred portal if MySky can't
+      // load.
+      //
+      // TODO: Add some infrastructure to return warnings to the skapp instead
+      // of errors?
+      console.warn(e);
     }
   }
 
@@ -690,15 +713,10 @@ export class MySky {
 
       // Check if the portal is valid and working before redirecting.
       const newUrlClient = new SkynetClient(newUrl);
-      try {
-        const portalUrl = await newUrlClient.portalUrl();
-        if (portalUrl) {
-          // Redirect.
-          redirectPage(newUrl);
-        }
-      } catch (e) {
-        // Don't throw an error here for now as this is likely user error.
-        console.warn(e);
+      const portalUrl = await newUrlClient.portalUrl();
+      if (portalUrl) {
+        // Redirect.
+        redirectPage(newUrl);
       }
     } else {
       // If we are on the preferred portal already, we still need to set the


### PR DESCRIPTION
# PULL REQUEST

## Overview

We don't want to fail to initialize MySky or to login if the portal redirect
fails. This can happen if the user entered an invalid portal, and in that case
he wouldn't be able to log in to change the portal.

Also, **this PR temporarily disables the portal redirect** until the autologin
changes in MySky are deployed.

## New Release

Once this is merged in the `master` branch, we can merge `master` into the
`beta` branch and release a new beta version which includes SkyDB V2 and has
parallel uploads re-enabled. (We can also start working on a new stable
release.)

## Testing

This commit was confirmed to be working by testing at:
https://bjftds.hns.siasky.net/

I have tested uploading files and directories. I also logged into the test user and 
ran "Test MySky". This now includes new SkyDB v2 tests on MySky.

The relevant PR for the test skapp can be found at:
https://github.com/SkynetLabs/test-skapp/pull/7

