### PR TITLE
Make `ExecuteRequestError` backwards-compatible with `AxiosError`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,8 @@ export {
 } from "./mysky/encrypted_files";
 export { deriveDiscoverableFileTweak } from "./mysky/tweak";
 export { getEntryLink, getEntryUrlForPortal, signEntry, validateRegistryProof } from "./registry";
+// Have to export `ExecuteRequestError` as a value instead of as a type or the
+// consumer cannot use `instanceof`.
 export { ExecuteRequestError } from "./request";
 export { DELETION_ENTRY_DATA, getOrCreateSkyDBRegistryEntry } from "./skydb_v2";
 export { convertSkylinkToBase32, convertSkylinkToBase64 } from "./skylink/format";

--- a/src/request.test.ts
+++ b/src/request.test.ts
@@ -1,0 +1,53 @@
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
+
+import { SkynetClient } from ".";
+import { ExecuteRequestError } from "./request";
+import { defaultSkynetPortalUrl } from "./utils/url";
+
+const portalUrl = defaultSkynetPortalUrl;
+const client = new SkynetClient(portalUrl);
+const skylink = "XABvi7JtJbQSMAcDwnUnmp2FKDPjg8_tTTFP4BwMSxVdEg";
+
+describe("ExecuteRequestError", () => {
+  let mock: MockAdapter;
+
+  beforeEach(() => {
+    mock = new MockAdapter(axios);
+    mock.resetHistory();
+  });
+
+  it("should have a working instanceof and also be an axios error", async () => {
+    try {
+      // Should result in a 404 as we haven't set up any mock handlers.
+      await client.getFileContent(skylink);
+      throw new Error("'getFileContent' should not have succeeded");
+    } catch (err) {
+      // Assert the type and that instanceof behaves as expected.
+      expect(err).toBeInstanceOf(ExecuteRequestError);
+      // NOTE: Backwards-compatibility check. Include this check as third-party
+      // devs may be assuming the network request error is still an
+      // `AxiosError`, and we don't want to break compatibility.
+      expect(axios.isAxiosError(err)).toBeTruthy();
+      expect((err as ExecuteRequestError).responseStatus).toEqual(404);
+    }
+  });
+
+  it("should not be able to be instantiated from another ExecuteRequestError", async () => {
+    // Get an `ExecuteRequestError`.
+    let error: ExecuteRequestError;
+    try {
+      // Should result in a 404 as we haven't set up any mock handlers.
+      await client.getFileContent(skylink);
+      throw new Error("'getFileContent' should not have succeeded");
+    } catch (err) {
+      error = err as ExecuteRequestError;
+    }
+
+    // Should not be able to instantiate an `ExecuteRequestError` from another
+    // `ExecuteRequestError`.
+    expect(() => ExecuteRequestError.From(error)).toThrowError(
+      "Could not instantiate an `ExecuteRequestError` from an `ExecuteRequestError`, an original error from axios was expected"
+    );
+  });
+});

--- a/src/request.test.ts
+++ b/src/request.test.ts
@@ -1,13 +1,14 @@
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
 
-import { SkynetClient } from ".";
-import { ExecuteRequestError } from "./request";
-import { defaultSkynetPortalUrl } from "./utils/url";
+import { ExecuteRequestError, SkynetClient } from ".";
+import { getSkylinkUrlForPortal } from "./download";
+import { DEFAULT_SKYNET_PORTAL_URL } from "./utils/url";
 
-const portalUrl = defaultSkynetPortalUrl;
+const portalUrl = DEFAULT_SKYNET_PORTAL_URL;
 const client = new SkynetClient(portalUrl);
 const skylink = "XABvi7JtJbQSMAcDwnUnmp2FKDPjg8_tTTFP4BwMSxVdEg";
+const skylinkUrl = getSkylinkUrlForPortal(portalUrl, skylink);
 
 describe("ExecuteRequestError", () => {
   let mock: MockAdapter;
@@ -18,10 +19,12 @@ describe("ExecuteRequestError", () => {
   });
 
   it("should have a working instanceof and also be an axios error", async () => {
+    mock.onGet(skylinkUrl).replyOnce(404);
+
     try {
-      // Should result in a 404 as we haven't set up any mock handlers.
+      // Should result in a 404.
       await client.getFileContent(skylink);
-      throw new Error("'getFileContent' should not have succeeded");
+      expect(true).toBeFalsy();
     } catch (err) {
       // Assert the type and that instanceof behaves as expected.
       expect(err).toBeInstanceOf(ExecuteRequestError);
@@ -34,12 +37,14 @@ describe("ExecuteRequestError", () => {
   });
 
   it("should not be able to be instantiated from another ExecuteRequestError", async () => {
+    mock.onGet(skylinkUrl).replyOnce(404);
+
     // Get an `ExecuteRequestError`.
     let error: ExecuteRequestError;
     try {
-      // Should result in a 404 as we haven't set up any mock handlers.
+      // Should result in a 404.
       await client.getFileContent(skylink);
-      throw new Error("'getFileContent' should not have succeeded");
+      expect(true).toBeFalsy();
     } catch (err) {
       error = err as ExecuteRequestError;
     }

--- a/src/request.test.ts
+++ b/src/request.test.ts
@@ -18,7 +18,7 @@ describe("ExecuteRequestError", () => {
     mock.resetHistory();
   });
 
-  it("should have a working instanceof and also be an axios error", async () => {
+  it("should have correct properties, a working instanceof, and also be an axios error", async () => {
     mock.onGet(skylinkUrl).replyOnce(404);
 
     try {
@@ -26,13 +26,21 @@ describe("ExecuteRequestError", () => {
       await client.getFileContent(skylink);
       expect(true).toBeFalsy();
     } catch (err) {
+      // Check some expected properties.
+      expect((err as ExecuteRequestError).name).toEqual("ExecuteRequestError");
+      expect((err as ExecuteRequestError).message).toEqual("Request failed with status code 404");
+      expect((err as ExecuteRequestError).responseStatus).toEqual(404);
+
       // Assert the type and that instanceof behaves as expected.
       expect(err).toBeInstanceOf(ExecuteRequestError);
+
       // NOTE: Backwards-compatibility check. Include this check as third-party
       // devs may be assuming the network request error is still an
       // `AxiosError`, and we don't want to break compatibility.
       expect(axios.isAxiosError(err)).toBeTruthy();
-      expect((err as ExecuteRequestError).responseStatus).toEqual(404);
+      expect((err as ExecuteRequestError).config).toEqual((err as ExecuteRequestError).originalError.config);
+      expect(typeof (err as ExecuteRequestError).config).toBe("object");
+      expect((err as ExecuteRequestError).config).toEqual(expect.objectContaining({ url: skylinkUrl }));
     }
   });
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -82,9 +82,7 @@ export async function buildRequestUrl(
  * compatible with, `AxiosError`.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export class ExecuteRequestError<T = any, D = any> implements AxiosError {
-  message: string;
-  name: string;
+export class ExecuteRequestError<T = any, D = any> extends Error implements AxiosError {
   responseStatus: number | null;
   responseMessage: string | null;
 
@@ -117,7 +115,7 @@ export class ExecuteRequestError<T = any, D = any> implements AxiosError {
     }
 
     // Set `Error` fields.
-    this.message = message;
+    super(message);
     this.name = "ExecuteRequestError";
 
     // Set `ExecuteRequestError` fields.

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,4 +1,4 @@
-import { AxiosError } from "axios";
+import { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
 
 import { SkynetClient } from "./client";
 import { addUrlQuery, addUrlSubdomain, ensureUrlPrefix, makeUrl } from "./utils/url";
@@ -77,26 +77,60 @@ export async function buildRequestUrl(
 }
 
 /**
- * The error type returned by `executeRequestError`.
+ * The error type returned by the SDK whenever it makes a network request
+ * (internally, this happens in `executeRequest`). It implements, so is
+ * compatible with, `AxiosError`.
  */
-export class ExecuteRequestError extends Error {
-  originalError: AxiosError;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export class ExecuteRequestError<T = any, D = any> implements AxiosError {
+  message: string;
+  name: string;
   responseStatus: number | null;
   responseMessage: string | null;
+
+  // Properties required by `AxiosError`.
+
+  config: AxiosRequestConfig<D>;
+  code?: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  request?: any;
+  response?: AxiosResponse<T, D>;
+  isAxiosError: boolean;
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  toJSON: () => object;
 
   /**
    * Creates an `ExecuteRequestError`.
    *
    * @param message - The error message.
-   * @param axiosError - The original axios error.
+   * @param axiosError - The original Axios error.
    * @param responseStatus - The response status, if found in the original error.
    * @param responseMessage - The response message, if found in the original error.
    */
   constructor(message: string, axiosError: AxiosError, responseStatus: number | null, responseMessage: string | null) {
-    super(message);
-    this.originalError = axiosError;
+    // Include this check since ExecuteRequestError implements AxiosError, but
+    // we only expect original errors from Axios here.
+    if (axiosError instanceof ExecuteRequestError) {
+      throw new Error(
+        "Could not instantiate an `ExecuteRequestError` from an `ExecuteRequestError`, an original error from axios was expected"
+      );
+    }
+
+    // Set `Error` fields.
+    this.message = message;
+    this.name = "ExecuteRequestError";
+
+    // Set `ExecuteRequestError` fields.
     this.responseStatus = responseStatus;
     this.responseMessage = responseMessage;
+
+    // Set properties required by `AxiosError`.
+    this.config = axiosError.config;
+    this.code = axiosError.code;
+    this.request = axiosError.request;
+    this.response = axiosError.response;
+    this.isAxiosError = axiosError.isAxiosError;
+    this.toJSON = axiosError.toJSON;
 
     // Required for `instanceof` to work.
     Object.setPrototypeOf(this, ExecuteRequestError.prototype);


### PR DESCRIPTION
# PULL REQUEST

## Overview

We previously made a change where we were returning a new error type,
`ExecuteRequestError`, from failed network requests instead of `AxiosError`. The
original Axios error was retrievable with `error.originalError`. This was a
break in compatibility for third-party devs who may have come to rely on
`AxiosError` being thrown.

This commit updates `ExecuteRequestError` to be fully compatible with
`AxiosError`. Now this won't be a breaking change.

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [ ] Changelog file created