### PR TITLE
use github secret to change integration tests portal

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -28,3 +28,5 @@ jobs:
       - run: yarn lint:eslint
       - run: yarn lint:tsc
       - run: yarn test
+        env:
+          SKYNET_JS_INTEGRATION_TEST_SERVER: ${{ secrets.SKYNET_JS_INTEGRATION_TEST_SERVER }}


### PR DESCRIPTION
Allow optional setting of `SKYNET_JS_INTEGRATION_TEST_SERVER` github secret to switch portal for integration tests.

This is to change the server from default siasky.net to something more stable in times that siasky.net act bumpy.