### PR TITLE
MySky portal redirect fixes

### DIFF
--- a/src/mysky/index.ts
+++ b/src/mysky/index.ts
@@ -181,7 +181,7 @@ export class MySky {
       // MySky expects to be on the same portal as the skapp, so create a new
       // client on the current skapp URL, in case the client the developer
       // instantiated does not correspond to the portal of the current URL.
-      const currentUrlClient = new SkynetClient(window.location.hostname);
+      const currentUrlClient = new SkynetClient(window.location.hostname, client.customOptions);
       try {
         // Trigger a resolve of the portal URL manually. `new SkynetClient`
         // assumes a portal URL is given to it, so it doesn't make the request
@@ -731,7 +731,7 @@ export class MySky {
       // portal, if it is set.
 
       // Set the skapp client to use the user's preferred portal.
-      this.connector.client = new SkynetClient(preferredPortalUrl);
+      this.connector.client = new SkynetClient(preferredPortalUrl, this.connector.client.customOptions);
     }
   }
 
@@ -741,7 +741,7 @@ export class MySky {
    * @param preferredPortalUrl - The user's preferred portal URL.
    */
   protected async redirectToPreferredPortalUrl(preferredPortalUrl: string): Promise<void> {
-    const currentDomainClient = new SkynetClient(this.hostDomain);
+    const currentDomainClient = new SkynetClient(this.hostDomain, this.connector.client.customOptions);
     const newUrl = await getRedirectUrlOnPreferredPortal(
       currentDomainClient,
       window.location.hostname,
@@ -749,7 +749,7 @@ export class MySky {
     );
 
     // Check if the portal is valid and working before redirecting.
-    const newUrlClient = new SkynetClient(newUrl);
+    const newUrlClient = new SkynetClient(newUrl, this.connector.client.customOptions);
     const portalUrl = await newUrlClient.portalUrl();
     if (portalUrl) {
       // Redirect.

--- a/src/mysky/index.ts
+++ b/src/mysky/index.ts
@@ -47,6 +47,7 @@ import {
   setJSON,
   setJSONEncrypted,
 } from "./skydb";
+import { trimForwardSlash } from "../utils/string";
 
 /**
  * The domain for MySky.
@@ -202,7 +203,7 @@ export class MySky {
       if (skappIsOnPortal) {
         hostDomain = await currentUrlClient.extractDomain(window.location.hostname);
       } else {
-        hostDomain = window.location.hostname;
+        hostDomain = trimForwardSlash(window.location.hostname);
       }
     }
 

--- a/src/mysky/index.ts
+++ b/src/mysky/index.ts
@@ -709,6 +709,7 @@ export class MySky {
       // Don't redirect on localhost as there is no subdomain to redirect to.
       return;
     }
+    const currentFullDomain = window.location.hostname;
 
     // Get the preferred portal.
     const preferredPortalUrl = await this.getPreferredPortal();
@@ -717,7 +718,7 @@ export class MySky {
     if (preferredPortalUrl === null) {
       // Preferred portal is not set.
       return;
-    } else if (this.skappIsOnPortal && shouldRedirectToPreferredPortalUrl(this.hostDomain, preferredPortalUrl)) {
+    } else if (this.skappIsOnPortal && shouldRedirectToPreferredPortalUrl(currentFullDomain, preferredPortalUrl)) {
       // Redirect to the appropriate URL on a different portal. If we're not on
       // a portal, don't redirect.
       //
@@ -742,12 +743,8 @@ export class MySky {
    * @param preferredPortalUrl - The user's preferred portal URL.
    */
   protected async redirectToPreferredPortalUrl(preferredPortalUrl: string): Promise<void> {
-    const currentDomainClient = new SkynetClient(this.hostDomain, this.connector.client.customOptions);
-    const newUrl = await getRedirectUrlOnPreferredPortal(
-      currentDomainClient,
-      window.location.hostname,
-      preferredPortalUrl
-    );
+    // Get the current skapp on the preferred portal.
+    const newUrl = await getRedirectUrlOnPreferredPortal(this.hostDomain, preferredPortalUrl);
 
     // Check if the portal is valid and working before redirecting.
     const newUrlClient = new SkynetClient(newUrl, this.connector.client.customOptions);

--- a/src/mysky/index.ts
+++ b/src/mysky/index.ts
@@ -130,13 +130,13 @@ export class MySky {
    * @param connector - The `Connector` object.
    * @param permissions - The initial requested permissions.
    * @param hostDomain - The domain of the host skapp.
-   * @param currentPortalUrl - The URL of the current portal. This is the portal that the skapp is running on, not the portal that may have been requested by the developer when creating a `SkynetClient`.
+   * @param skappIsOnPortal - Whether the current skapp is on a portal.
    */
   constructor(
     protected connector: Connector,
     permissions: Permission[],
     protected hostDomain: string,
-    protected currentPortalUrl: string
+    protected skappIsOnPortal: boolean
   ) {
     if (MySky.instance) {
       throw new Error("Trying to create a second MySky instance");
@@ -173,28 +173,37 @@ export class MySky {
     }
     const connector = await Connector.init(client, domain, customOptions);
 
-    let currentPortalUrl;
     let hostDomain;
+    let skappIsOnPortal = false;
     if (window.location.hostname === "localhost") {
-      currentPortalUrl = window.location.href;
       hostDomain = "localhost";
     } else {
       // MySky expects to be on the same portal as the skapp, so create a new
       // client on the current skapp URL, in case the client the developer
       // instantiated does not correspond to the portal of the current URL.
       const currentUrlClient = new SkynetClient(window.location.hostname);
-      // Trigger a resolve of the portal URL manually. `new SkynetClient` assumes
-      // a portal URL is given to it, so it doesn't make the request for the
-      // actual portal URL.
-      //
-      // TODO: We should rework this so it is possible without protected methods.
-      //
-      // @ts-expect-error - Using protected fields.
-      currentUrlClient.customPortalUrl = await currentUrlClient.resolvePortalUrl();
-      currentPortalUrl = await currentUrlClient.portalUrl();
+      try {
+        // Trigger a resolve of the portal URL manually. `new SkynetClient`
+        // assumes a portal URL is given to it, so it doesn't make the request
+        // for the actual portal URL.
+        //
+        // TODO: We should rework this so it is possible without protected
+        // methods.
+        //
+        // @ts-expect-error - Using protected method.
+        currentUrlClient.customPortalUrl = await currentUrlClient.resolvePortalUrl();
+        skappIsOnPortal = true;
+      } catch (e) {
+        // Could not make a query for the portal URL, we are not on a portal.
+        skappIsOnPortal = false;
+      }
 
       // Get the host domain.
-      hostDomain = await currentUrlClient.extractDomain(window.location.hostname);
+      if (skappIsOnPortal) {
+        hostDomain = await currentUrlClient.extractDomain(window.location.hostname);
+      } else {
+        hostDomain = window.location.hostname;
+      }
     }
 
     // Extract the skapp domain.
@@ -206,7 +215,7 @@ export class MySky {
       permissions.push(perm1, perm2, perm3);
     }
 
-    MySky.instance = new MySky(connector, permissions, hostDomain, currentPortalUrl);
+    MySky.instance = new MySky(connector, permissions, hostDomain, skappIsOnPortal);
 
     // Redirect if we're not on the preferred portal. See
     // `redirectIfNotOnPreferredPortal` for full load flow.
@@ -675,8 +684,8 @@ export class MySky {
    *     2. If it is not set or we don't have the seed, MySky switches to using
    *        the current portal as opposed to siasky.net.
    *  5. After MySky finishes loading, SDK queries `mySky.getPortalPreference`.
-   *  6. If the preferred portal is set and different than the current portal,
-   *     SDK triggers refresh.
+   *  6. If we are on a portal, and the preferred portal is set and different
+   *     than the current portal, SDK triggers redirect to the new portal.
    *  7. We go back to step 1 and repeat, but since we're on the right portal
    *     now we won't refresh in step 6.
    *
@@ -695,8 +704,7 @@ export class MySky {
    *    refresh in step 6.
    */
   protected async redirectIfNotOnPreferredPortal(): Promise<void> {
-    const currentDomain = window.location.hostname;
-    if (currentDomain === "localhost") {
+    if (this.hostDomain === "localhost") {
       // Don't redirect on localhost as there is no subdomain to redirect to.
       return;
     }
@@ -706,34 +714,46 @@ export class MySky {
 
     // Is the preferred portal set and different from the current portal?
     if (preferredPortalUrl === null) {
+      // Preferred portal is not set.
       return;
-    } else if (shouldRedirectToPreferredPortalUrl(currentDomain, preferredPortalUrl)) {
-      // Redirect to the appropriate URL.
+    } else if (this.skappIsOnPortal && shouldRedirectToPreferredPortalUrl(this.hostDomain, preferredPortalUrl)) {
+      // Redirect to the appropriate URL on a different portal. If we're not on
+      // a portal, don't redirect.
       //
       // Get the redirect URL based on the current URL. (Don't use current
       // client as the developer may have set it to e.g. siasky.dev when we are
       // really on siasky.net.)
-      const currentDomainClient = new SkynetClient(currentDomain);
-      const newUrl = await getRedirectUrlOnPreferredPortal(
-        currentDomainClient,
-        window.location.hostname,
-        preferredPortalUrl
-      );
-
-      // Check if the portal is valid and working before redirecting.
-      const newUrlClient = new SkynetClient(newUrl);
-      const portalUrl = await newUrlClient.portalUrl();
-      if (portalUrl) {
-        // Redirect.
-        redirectPage(newUrl);
-      }
+      await this.redirectToPreferredPortalUrl(preferredPortalUrl);
     } else {
-      // If we are on the preferred portal already, we still need to set the
-      // client as the developer may have chosen a specific client. We always
-      // want to use the user's preference for a portal, if it is set.
+      // If we are on the preferred portal already, or not on a portal at all,
+      // we still need to set the client as the developer may have chosen a
+      // specific client. We always want to use the user's preference for a
+      // portal, if it is set.
 
       // Set the skapp client to use the user's preferred portal.
       this.connector.client = new SkynetClient(preferredPortalUrl);
+    }
+  }
+
+  /**
+   * Redirects to the given portal URL.
+   *
+   * @param preferredPortalUrl - The user's preferred portal URL.
+   */
+  protected async redirectToPreferredPortalUrl(preferredPortalUrl: string): Promise<void> {
+    const currentDomainClient = new SkynetClient(this.hostDomain);
+    const newUrl = await getRedirectUrlOnPreferredPortal(
+      currentDomainClient,
+      window.location.hostname,
+      preferredPortalUrl
+    );
+
+    // Check if the portal is valid and working before redirecting.
+    const newUrlClient = new SkynetClient(newUrl);
+    const portalUrl = await newUrlClient.portalUrl();
+    if (portalUrl) {
+      // Redirect.
+      redirectPage(newUrl);
     }
   }
 

--- a/src/mysky/utils.test.ts
+++ b/src/mysky/utils.test.ts
@@ -125,41 +125,20 @@ const portal2Urls = combineStrings(["", "http://", "https://", "HTTPS://"], ["si
 
 // TODO: Test cases with portal servers.
 describe("getRedirectUrlOnPreferredPortal", () => {
-  let mock: MockAdapter;
-
-  beforeEach(() => {
-    mock = new MockAdapter(axios);
-  });
-
-  const portal1SkappUrls = combineStrings(["", "https://"], ["skapp.hns.siasky.net"], ["", "/"]);
-  const portal2SkappUrls = combineStrings(["", "https://"], ["skapp.hns.siasky.xyz"], ["", "/"]);
-
-  const cases: Array<[string, string, string, string]> = [
+  const cases: Array<[string, string, string]> = [
     // Test redirecting from one portal to another.
-    ...(composeTestCases(combineArrays(portal1SkappUrls, portal2Urls), "https://skapp.hns.siasky.xyz").map(
-      ([[a, b], c]) => ["siasky.net", a, b, c]
-    ) as [string, string, string, string][]),
-    ...(composeTestCases(combineArrays(portal2SkappUrls, portal1Urls), "https://skapp.hns.siasky.net").map(
-      ([[a, b], c]) => ["siasky.xyz", a, b, c]
-    ) as [string, string, string, string][]),
+    ...(composeTestCases(combineArrays(["skapp.hns"], portal2Urls), "https://skapp.hns.siasky.xyz").map(
+      ([[a, b], c]) => [a, b, c]
+    ) as [string, string, string][]),
+    ...(composeTestCases(combineArrays(["skapp.hns"], portal1Urls), "https://skapp.hns.siasky.net").map(
+      ([[a, b], c]) => [a, b, c]
+    ) as [string, string, string][]),
   ];
 
-  it.each(cases)(
-    "('%s', '%s', '%s') should return '%s'",
-    async (portalDomain, currentUrl, preferredPortalUrl, expectedResult) => {
-      const portalUrl = `https://${portalDomain}`;
-      // Responses for regular portal.
-      mock
-        .onHead(portalUrl)
-        .replyOnce(200, {}, { "skynet-server-api": `us-va-1.${portalDomain}` })
-        .onHead(portalUrl)
-        .replyOnce(200, {}, { "skynet-portal-api": portalDomain });
-
-      const client = new SkynetClient(portalUrl);
-      const result = await getRedirectUrlOnPreferredPortal(client, currentUrl, preferredPortalUrl);
-      expect(result).toEqual(expectedResult);
-    }
-  );
+  it.each(cases)("('%s', '%s') should return '%s'", async (hostDomain, preferredPortalUrl, expectedResult) => {
+    const result = await getRedirectUrlOnPreferredPortal(hostDomain, preferredPortalUrl);
+    expect(result).toEqual(expectedResult);
+  });
 });
 
 // TODO: Add cases with portal servers.

--- a/src/mysky/utils.ts
+++ b/src/mysky/utils.ts
@@ -1,5 +1,5 @@
 import { SkynetClient } from "../client";
-import { trimForwardSlash, trimSuffix } from "../utils/string";
+import { trimForwardSlash } from "../utils/string";
 import { getFullDomainUrlForPortal, extractDomainForPortal, ensureUrlPrefix } from "../utils/url";
 
 /**
@@ -23,18 +23,15 @@ export async function getFullDomainUrl(this: SkynetClient, domain: string): Prom
  * Gets the URL for the current skapp on the preferred portal, if we're not on
  * the preferred portal already.
  *
- * @param client - The Skynet client.
- * @param currentUrl - The current page URL.
+ * @param skappDomain - The current page URL.
  * @param preferredPortalUrl - The preferred portal URL.
  * @returns - The URL for the current skapp on the preferred portal.
  */
 export async function getRedirectUrlOnPreferredPortal(
-  client: SkynetClient,
-  currentUrl: string,
+  skappDomain: string,
   preferredPortalUrl: string
 ): Promise<string> {
   // Get the current skapp on the preferred portal.
-  const skappDomain = await client.extractDomain(currentUrl);
   return getFullDomainUrlForPortal(preferredPortalUrl, skappDomain);
 }
 
@@ -119,13 +116,13 @@ export function popupCenter(url: string, winName: string, w: number, h: number):
  * portal. The protocol prefixes are allowed to be different and there can be
  * other differences like a trailing slash.
  *
- * @param currentDomain - The current domain.
+ * @param currentFullDomain - The current domain.
  * @param preferredPortalUrl - The preferred portal URL.
  * @returns - Whether the two URLs are equal for the purposes of redirecting.
  */
-export function shouldRedirectToPreferredPortalUrl(currentDomain: string, preferredPortalUrl: string): boolean {
+export function shouldRedirectToPreferredPortalUrl(currentFullDomain: string, preferredPortalUrl: string): boolean {
   // Strip protocol and trailing slash (case-insensitive).
-  currentDomain = trimSuffix(currentDomain.replace(/https:\/\/|http:\/\//i, ""), "/");
-  preferredPortalUrl = trimSuffix(preferredPortalUrl.replace(/https:\/\/|http:\/\//i, ""), "/");
-  return !currentDomain.endsWith(preferredPortalUrl);
+  currentFullDomain = trimForwardSlash(currentFullDomain.replace(/https:\/\/|http:\/\//i, ""));
+  preferredPortalUrl = trimForwardSlash(preferredPortalUrl.replace(/https:\/\/|http:\/\//i, ""));
+  return !currentFullDomain.endsWith(preferredPortalUrl);
 }


### PR DESCRIPTION
# PULL REQUEST

## Overview

- [Don't redirect to a preferred portal if we are not on a portal](https://github.com/SkynetLabs/skynet-js/commit/0ef69a5371468151c16aa25dc24d67e00b88830b)
  - If we are not on a portal, we can't extract a skapp domain so it is impossible to redirect to a different portal. 
  - In this case, we simply set client requests to use the preferred portal.
- [Fix MySky being loaded without API key (always pass custom options)](https://github.com/SkynetLabs/skynet-js/commit/707bb8efdeb4dea3e701c99eb35cdb126661272c)
  - MySky can't be loaded without an API key on portals requiring user authentication.