### PR TITLE
Add `getFileContentBinary` and `getFileContentBinaryHns`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
+
 For the latest beta changes, see [CHANGELOG-BETA.md](./CHANGELOG-BETA.md).
+
+## [Unreleased]
+
+### Added
+
+- Added `client.getFileContentBinary` and `client.getFileContentBinaryHns` methods for downloading binary data.
 
 ## [3.0.2]
 

--- a/integration/upload_download.test.ts
+++ b/integration/upload_download.test.ts
@@ -158,13 +158,26 @@ describe(`Upload and download end-to-end tests for portal '${portal}'`, () => {
     expect(contentType).toEqual("application/octet-stream");
   });
 
-  it('should get binary data with responseType: "arraybuffer"', async () => {
+  it('getFileContent should get binary data with responseType: "arraybuffer"', async () => {
     const file = new File(["foo"], "bar");
     const { skylink } = await client.uploadFile(file);
 
     // Get file content and check returned values.
 
     const { data, contentType } = await client.getFileContent(skylink, { responseType: "arraybuffer" });
+
+    expect(typeof data).toEqual("object");
+    expect(data instanceof ArrayBuffer).toBeTruthy();
+    expect(contentType).toEqual("application/octet-stream");
+  });
+
+  it("getFileContentBinary should get binary data", async () => {
+    const file = new File(["foo"], "bar");
+    const { skylink } = await client.uploadFile(file);
+
+    // Get file content and check returned values.
+
+    const { data, contentType } = await client.getFileContentBinary(skylink);
 
     expect(typeof data).toEqual("object");
     expect(data instanceof ArrayBuffer).toBeTruthy();

--- a/integration/upload_download.test.ts
+++ b/integration/upload_download.test.ts
@@ -1,9 +1,10 @@
 import { client, dataKey, portal } from ".";
-import { convertSkylinkToBase64, genKeyPairAndSeed, uriSkynetPrefix } from "../src";
+import { convertSkylinkToBase64, genKeyPairAndSeed, uint8ArrayToStringUtf8, URI_SKYNET_PREFIX } from "../src";
 import { randomUnicodeString } from "../utils/testing";
 
 describe(`Upload and download end-to-end tests for portal '${portal}'`, () => {
   const fileData = "testing";
+  const binaryData = [0, 1, 2, 3];
   const json = { key: "testdownload" };
   const plaintextType = "text/plain";
   const plaintextMetadata = {
@@ -17,7 +18,7 @@ describe(`Upload and download end-to-end tests for portal '${portal}'`, () => {
 
   it("Should get file content for an existing entry link of depth 1", async () => {
     const entryLink = "AQDwh1jnoZas9LaLHC_D4-2yP9XYDdZzNtz62H4Dww1jDA";
-    const expectedDataLink = `${uriSkynetPrefix}XABvi7JtJbQSMAcDwnUnmp2FKDPjg8_tTTFP4BwMSxVdEg`;
+    const expectedDataLink = `${URI_SKYNET_PREFIX}XABvi7JtJbQSMAcDwnUnmp2FKDPjg8_tTTFP4BwMSxVdEg`;
 
     const { skylink } = await client.getFileContent(entryLink);
     expect(skylink).toEqual(expectedDataLink);
@@ -26,7 +27,7 @@ describe(`Upload and download end-to-end tests for portal '${portal}'`, () => {
   it("Should get file content for an existing entry link of depth 2", async () => {
     const entryLinkBase32 = "0400mgds8arrfnu8e6b0sde9fbkmh4nl2etvun55m0fvidudsb7bk78";
     const entryLink = convertSkylinkToBase64(entryLinkBase32);
-    const expectedDataLink = `${uriSkynetPrefix}EAAFgq17B-MKsi0ARYKUMmf9vxbZlDpZkA6EaVBCG4YBAQ`;
+    const expectedDataLink = `${URI_SKYNET_PREFIX}EAAFgq17B-MKsi0ARYKUMmf9vxbZlDpZkA6EaVBCG4YBAQ`;
 
     const { skylink } = await client.getFileContent(entryLink);
     expect(skylink).toEqual(expectedDataLink);
@@ -158,29 +159,46 @@ describe(`Upload and download end-to-end tests for portal '${portal}'`, () => {
     expect(contentType).toEqual("application/octet-stream");
   });
 
-  it('getFileContent should get binary data with responseType: "arraybuffer"', async () => {
-    const file = new File(["foo"], "bar");
+  // Regression test.
+  it('getFileContent should corrupt binary data if the responseType is not "arraybuffer"', async () => {
+    const file = new File([new Uint8Array(binaryData).buffer], "bar");
     const { skylink } = await client.uploadFile(file);
 
     // Get file content and check returned values.
 
-    const { data, contentType } = await client.getFileContent(skylink, { responseType: "arraybuffer" });
+    const { data, contentType } = await client.getFileContent(skylink);
 
-    expect(typeof data).toEqual("object");
+    expect(typeof data === "string").toBeTruthy();
+    const corruptedString = uint8ArrayToStringUtf8(new Uint8Array(binaryData));
+    expect(data).toEqual(corruptedString);
+    // The data should not equal the original raw data.
+    expect(data).not.toEqual(binaryData);
+    expect(contentType).toEqual("application/octet-stream");
+  });
+
+  it('getFileContent should get binary data with responseType: "arraybuffer"', async () => {
+    const file = new File([new Uint8Array(binaryData).buffer], "bar");
+    const { skylink } = await client.uploadFile(file);
+
+    // Get file content and check returned values.
+
+    const { data, contentType } = await client.getFileContent<ArrayBuffer>(skylink, { responseType: "arraybuffer" });
+
     expect(data instanceof ArrayBuffer).toBeTruthy();
+    expect(new Uint8Array(data)).toEqualUint8Array(new Uint8Array(binaryData));
     expect(contentType).toEqual("application/octet-stream");
   });
 
   it("getFileContentBinary should get binary data", async () => {
-    const file = new File(["foo"], "bar");
+    const file = new File([new Uint8Array(binaryData).buffer], "bar");
     const { skylink } = await client.uploadFile(file);
 
     // Get file content and check returned values.
 
     const { data, contentType } = await client.getFileContentBinary(skylink);
 
-    expect(typeof data).toEqual("object");
-    expect(data instanceof ArrayBuffer).toBeTruthy();
+    expect(data instanceof Uint8Array).toBeTruthy();
+    expect(data).toEqualUint8Array(new Uint8Array(binaryData));
     expect(contentType).toEqual("application/octet-stream");
   });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -24,6 +24,8 @@ import {
   openFile,
   openFileHns,
   resolveHns,
+  getFileContentBinary,
+  getFileContentBinaryHns,
 } from "./download";
 // These imports are deprecated but they are needed to export the v1 File
 // methods, which we are keeping so as not to break compatibility.
@@ -166,8 +168,10 @@ export class SkynetClient {
   getHnsresUrl = getHnsresUrl;
   getMetadata = getMetadata;
   getFileContent = getFileContent;
+  getFileContentBinary = getFileContentBinary;
   protected getFileContentRequest = getFileContentRequest;
   getFileContentHns = getFileContentHns;
+  getFileContentBinaryHns = getFileContentBinaryHns;
   openFile = openFile;
   openFileHns = openFileHns;
   resolveHns = resolveHns;

--- a/src/download.test.ts
+++ b/src/download.test.ts
@@ -453,6 +453,44 @@ describe("getFileContent", () => {
   });
 });
 
+describe("getFileContentBinary", () => {
+  let mock: MockAdapter;
+
+  beforeEach(() => {
+    mock = new MockAdapter(axios);
+    mock.onHead(portalUrl).replyOnce(200, {}, { "skynet-portal-api": portalUrl });
+  });
+
+  const skynetFileContents = { arbitrary: "json string" };
+  const headers = {
+    "skynet-portal-api": portalUrl,
+    "skynet-skylink": skylink,
+    "content-type": "application/json",
+  };
+
+  it('should throw if responseType option is not "arraybuffer"', async () => {
+    // This should throw.
+    await expect(client.getFileContentBinary(skylink, { responseType: "json" })).rejects.toThrowError(
+      "Unexpected 'responseType' option found for 'getFileContentBinary': 'json'"
+    );
+  });
+
+  it('should not throw if responseType option is "arraybuffer"', async () => {
+    mock.onGet(expectedUrl).replyOnce(200, skynetFileContents, headers);
+
+    // Should not throw if "arraybuffer" is passed.
+    const {
+      data,
+      contentType,
+      skylink: skylink2,
+    } = await client.getFileContentBinary(skylink, { responseType: "arraybuffer" });
+
+    expect(data).toEqual(skynetFileContents);
+    expect(contentType).toEqual("application/json");
+    expect(skylink2).toEqual(sialink);
+  });
+});
+
 describe("getFileContentHns", () => {
   let mock: MockAdapter;
 
@@ -475,6 +513,39 @@ describe("getFileContentHns", () => {
     mock.onGet(hnsresUrl).reply(200, { skylink });
 
     const { data } = await client.getFileContentHns(domain);
+
+    expect(data).toEqual(skynetFileContents);
+  });
+});
+
+describe("getFileContentBinaryHns", () => {
+  let mock: MockAdapter;
+
+  beforeEach(() => {
+    mock = new MockAdapter(axios);
+    mock.onHead(portalUrl).replyOnce(200, {}, { "skynet-portal-api": portalUrl });
+  });
+
+  const skynetFileContents = { arbitrary: "json string" };
+  const headers = {
+    "skynet-portal-api": portalUrl,
+    "skynet-skylink": skylink,
+    "content-type": "application/json",
+  };
+
+  it('should throw if responseType option is not "arraybuffer"', async () => {
+    // This should throw.
+    await expect(client.getFileContentBinaryHns(skylink, { responseType: "json" })).rejects.toThrowError(
+      "Unexpected 'responseType' option found for 'getFileContentBinary': 'json'"
+    );
+  });
+
+  it("should succeed with given domain", async () => {
+    mock.onGet(expectedHnsUrl).reply(200, skynetFileContents, headers);
+    mock.onGet(expectedHnsresUrl).reply(200, { skylink });
+
+    // Should not throw if "arraybuffer" is passed.
+    const { data } = await client.getFileContentBinaryHns(hnsLink);
 
     expect(data).toEqual(skynetFileContents);
   });

--- a/src/download.test.ts
+++ b/src/download.test.ts
@@ -461,7 +461,6 @@ describe("getFileContentBinary", () => {
     mock.onHead(portalUrl).replyOnce(200, {}, { "skynet-portal-api": portalUrl });
   });
 
-  const skynetFileContents = { arbitrary: "json string" };
   const headers = {
     "skynet-portal-api": portalUrl,
     "skynet-skylink": skylink,
@@ -476,7 +475,9 @@ describe("getFileContentBinary", () => {
   });
 
   it('should not throw if responseType option is "arraybuffer"', async () => {
-    mock.onGet(expectedUrl).replyOnce(200, skynetFileContents, headers);
+    const binaryData = [0, 1, 2, 3];
+
+    mock.onGet(expectedUrl).replyOnce(200, binaryData, headers);
 
     // Should not throw if "arraybuffer" is passed.
     const {
@@ -485,7 +486,7 @@ describe("getFileContentBinary", () => {
       skylink: skylink2,
     } = await client.getFileContentBinary(skylink, { responseType: "arraybuffer" });
 
-    expect(data).toEqual(skynetFileContents);
+    expect(data).toEqual(new Uint8Array(binaryData));
     expect(contentType).toEqual("application/json");
     expect(skylink2).toEqual(sialink);
   });

--- a/src/download.test.ts
+++ b/src/download.test.ts
@@ -527,7 +527,6 @@ describe("getFileContentBinaryHns", () => {
     mock.onHead(portalUrl).replyOnce(200, {}, { "skynet-portal-api": portalUrl });
   });
 
-  const skynetFileContents = { arbitrary: "json string" };
   const headers = {
     "skynet-portal-api": portalUrl,
     "skynet-skylink": skylink,
@@ -542,13 +541,15 @@ describe("getFileContentBinaryHns", () => {
   });
 
   it("should succeed with given domain", async () => {
-    mock.onGet(expectedHnsUrl).reply(200, skynetFileContents, headers);
+    const binaryData = [0, 1, 2, 3];
+
+    mock.onGet(expectedHnsUrl).reply(200, binaryData, headers);
     mock.onGet(expectedHnsresUrl).reply(200, { skylink });
 
     // Should not throw if "arraybuffer" is passed.
     const { data } = await client.getFileContentBinaryHns(hnsLink);
 
-    expect(data).toEqual(skynetFileContents);
+    expect(data).toEqual(new Uint8Array(binaryData));
   });
 });
 

--- a/src/download.ts
+++ b/src/download.ts
@@ -523,7 +523,7 @@ export async function getFileContentBinaryHns(
   // Set the expected response type so that we receive uncorrupted binary data.
   customOptions = { ...customOptions, responseType: "arraybuffer" };
 
-  const response = await this.getFileContent<ArrayBuffer>(domain, customOptions);
+  const response = await this.getFileContentHns<ArrayBuffer>(domain, customOptions);
   return { ...response, data: new Uint8Array(response.data) };
 }
 

--- a/src/download.ts
+++ b/src/download.ts
@@ -382,7 +382,7 @@ export async function getMetadata(
  * @param skylinkUrl - Skylink string. See `downloadFile`.
  * @param [customOptions] - Additional settings that can optionally be set.
  * @param [customOptions.endpointDownload="/"] - The relative URL path of the portal endpoint to contact.
- * @returns - An object containing the data of the file, the content-type, portal URL, and the file's skylink. The type of the data returned depends on the content-type of the file. For JSON files the return type should be a JSON object, for other files it should be a string. In order to return a Uint8Array for binary files, the `responseType` option should be set to "arraybuffer".
+ * @returns - An object containing the data of the file, the content-type, portal URL, and the file's skylink. The type of the data returned depends on the content-type of the file. For JSON files the return type should be a JSON object, for other files it should be a string. In order to return an ArrayBuffer for binary files, the `responseType` option should be set to "arraybuffer".
  * @throws - Will throw if the skylinkUrl does not contain a skylink or if the path option is not a string.
  */
 export async function getFileContent<T = unknown>(
@@ -423,7 +423,8 @@ export async function getFileContentBinary(
   // Set the expected response type so that we receive uncorrupted binary data.
   customOptions = { ...customOptions, responseType: "arraybuffer" };
 
-  return await this.getFileContent<Uint8Array>(skylinkUrl, customOptions);
+  const response = await this.getFileContent<ArrayBuffer>(skylinkUrl, customOptions);
+  return { ...response, data: new Uint8Array(response.data) };
 }
 
 /**
@@ -467,7 +468,7 @@ export async function getFileContentRequest(
  * @param domain - Handshake domain.
  * @param [customOptions] - Additional settings that can optionally be set.
  * @param [customOptions.endpointDownloadHns="/hns"] - The relative URL path of the portal endpoint to contact.
- * @returns - An object containing the data of the file, the content-type, portal URL, and the file's skylink. The type of the data returned depends on the content-type of the file. For JSON files the return type should be a JSON object, for other files it should be a string. In order to return a Uint8Array for binary files, the `responseType` option should be set to "arraybuffer".
+ * @returns - An object containing the data of the file, the content-type, portal URL, and the file's skylink. The type of the data returned depends on the content-type of the file. For JSON files the return type should be a JSON object, for other files it should be a string. In order to return an ArrayBuffer for binary files, the `responseType` option should be set to "arraybuffer".
  * @throws - Will throw if the domain does not contain a skylink.
  */
 export async function getFileContentHns<T = unknown>(
@@ -522,7 +523,8 @@ export async function getFileContentBinaryHns(
   // Set the expected response type so that we receive uncorrupted binary data.
   customOptions = { ...customOptions, responseType: "arraybuffer" };
 
-  return await this.getFileContentHns<Uint8Array>(domain, customOptions);
+  const response = await this.getFileContent<ArrayBuffer>(domain, customOptions);
+  return { ...response, data: new Uint8Array(response.data) };
 }
 
 /**

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -9,7 +9,9 @@ describe("SkynetClient", () => {
     expect(client).toHaveProperty("downloadFile");
     expect(client).toHaveProperty("downloadFileHns");
     expect(client).toHaveProperty("getFileContent");
+    expect(client).toHaveProperty("getFileContentBinary");
     expect(client).toHaveProperty("getFileContentHns");
+    expect(client).toHaveProperty("getFileContentBinaryHns");
     expect(client).toHaveProperty("getHnsUrl");
     expect(client).toHaveProperty("getHnsresUrl");
     expect(client).toHaveProperty("getSkylinkUrl");

--- a/src/pin.test.ts
+++ b/src/pin.test.ts
@@ -1,15 +1,15 @@
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
 
-import { SkynetClient, defaultSkynetPortalUrl, uriSkynetPrefix } from "./index";
+import { SkynetClient, DEFAULT_SKYNET_PORTAL_URL, URI_SKYNET_PREFIX } from "./index";
 
-const portalUrl = defaultSkynetPortalUrl;
+const portalUrl = DEFAULT_SKYNET_PORTAL_URL;
 const client = new SkynetClient(portalUrl);
 const skylink = "XABvi7JtJbQSMAcDwnUnmp2FKDPjg8_tTTFP4BwMSxVdEg";
-const sialink = `${uriSkynetPrefix}${skylink}`;
+const sialink = `${URI_SKYNET_PREFIX}${skylink}`;
 const expectedUrl = `${portalUrl}/skynet/pin/${skylink}`;
 
-describe("getFileContent", () => {
+describe("pinSkylink", () => {
   let mock: MockAdapter;
 
   beforeEach(() => {


### PR DESCRIPTION
# PULL REQUEST

## Overview

Due to a peculiarity in axios, `getFileContent` doesn't return binary data
unless you explicitly set the `responseType` option. By default it returns a
string, corrupting data that is actually composed of raw bytes. I feel that this
is such a common case that we should introduce `getFileContentBinary`.

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created