### PR TITLE
Remove initial OPTIONS checking if parallel uploads are supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Types of changes:
 - Added `chunkSizeMultiplier` option for large file uploads.
 - Added `staggerPercent` option for more efficient uploading of large file uploads.
 
+### Changed
+
+- Large file uploads now make one less request before starting an upload.
+
 ## [4.1.0]
 
 ### Breaking Changes


### PR DESCRIPTION
# PULL REQUEST

## Overview

We no longer need to check for whether concat is enabled. The parallel uploads feature should be present on all servers by now.

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created