### PR TITLE
Fix broken single-chunk uploads when chunkSizeMultiplier > 1

### DIFF
--- a/src/upload.ts
+++ b/src/upload.ts
@@ -123,7 +123,7 @@ export async function uploadFile(
 
   const opts = { ...DEFAULT_UPLOAD_OPTIONS, ...this.customOptions, ...customOptions };
 
-  if (file.size < opts.largeFileSize) {
+  if (file.size < opts.largeFileSize * opts.chunkSizeMultiplier) {
     return this.uploadSmallFile(file, opts);
   } else {
     return this.uploadLargeFile(file, opts);


### PR DESCRIPTION
# PULL REQUEST

## Overview

I missed this because we added the `Expected parameter 'totalSize' to be greater
than the size of a chunk` check late in review, and I only tested
`chunkSizeMultiplier: 1` after that.

### Testing

Changes deployed here:
https://bjftds.hns.siasky.net/
Set `chunkSizeMultiplier: 3`.

[Why we don't have integration tests.](https://linear.app/skynetlabs/issue/SKY-304/add-tus-testing-to-integration-tests-health-checks)

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

#### Before
![](https://cdn.discordapp.com/attachments/773635079457079306/978687529324773456/unknown.png)

#### After
Should be no error!