### PR TITLE
Fix getFileContentHns error: skylink comparison

### DIFF
--- a/CHANGELOG-BETA.md
+++ b/CHANGELOG-BETA.md
@@ -35,11 +35,11 @@ Types of changes:
 
 ### Added
 
-- Throws error when passing both dev and alpha options for MySky (#257). by @amberm31 in https://github.com/SkynetLabs/skynet-js/pull/352
+- Throws error when passing both dev and alpha options for MySky (#257). By @amberm31 in https://github.com/SkynetLabs/skynet-js/pull/352
 
 ### Changed
 
-- Mysky login flow fixes by @m-cat in https://github.com/SkynetLabs/skynet-js/pull/403
+- Mysky login flow fixes. By @m-cat in https://github.com/SkynetLabs/skynet-js/pull/403
 
 ## [4.0.26-beta]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Types of changes:
 
 - Large file uploads now make one less request before starting an upload.
 - Improved performance and stability of integration tests.
+- Fixed `getFileContentHns` error due to bad skylink comparison.
 
 ## [4.1.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Types of changes:
 
 - Large file uploads now make one less request before starting an upload.
 - Improved performance and stability of integration tests.
-- Fixed `getFileContentHns` error due to bad skylink comparison.
+- Fixed `getFileContentHns` error due to bad skylink comparison. By @parajbs in https://github.com/SkynetLabs/skynet-js/issues/479
 
 ## [4.1.0]
 

--- a/integration/upload_download.test.ts
+++ b/integration/upload_download.test.ts
@@ -337,6 +337,17 @@ describe(`Upload and download end-to-end tests for portal '${portal}'`, () => {
       /Failed to resolve skylink|Request failed with status code 404: failed to fetch skylink: registry entry not found within given time/
     );
   });
+
+  describe("getFileContentHns", () => {
+    it("should query an existing domain", async () => {
+      const domain = "skynet-mysky"; // We're in control of this and it shouldn't change.
+
+      const { contentType, portalUrl, skylink: returnedSkylink } = await client.getFileContentHns(domain);
+      expect(contentType).toEqual("text/html");
+      expect(portalUrl).toEqualPortalUrl(portal);
+      expect(returnedSkylink).toContain("sia://");
+    });
+  });
 });
 
 /**

--- a/src/download.test.ts
+++ b/src/download.test.ts
@@ -353,7 +353,7 @@ describe("getFileContent", () => {
       mock.onGet(expectedUrl).reply(200, {}, headersWithProof);
 
       await expect(client.getFileContent(skylink)).rejects.toThrowError(
-        "File content response invalid despite a successful request. Please try again and report this issue to the devs if it persists. Error: Expected returned skylink to be the same as input data link"
+        "File content response invalid despite a successful request. Please try again and report this issue to the devs if it persists. Error: Expected returned skylink ('AQDwh1jnoZas9LaLHC_D4-2yP9XYDdZzNtz62H4Dww1jDA') to be the same as input data link ('XABvi7JtJbQSMAcDwnUnmp2FKDPjg8_tTTFP4BwMSxVdEg')"
       );
     });
 
@@ -376,7 +376,7 @@ describe("getFileContent", () => {
       mock.onGet(expectedEntryLinkUrl).reply(200, {}, headersWithProof);
 
       await expect(client.getFileContent(entryLink)).rejects.toThrowError(
-        "File content response invalid despite a successful request. Please try again and report this issue to the devs if it persists. Error: Expected returned skylink to be different from input entry link"
+        "File content response invalid despite a successful request. Please try again and report this issue to the devs if it persists. Error: Expected returned skylink ('AQDwh1jnoZas9LaLHC_D4-2yP9XYDdZzNtz62H4Dww1jDA') to be different from input entry link"
       );
     });
 


### PR DESCRIPTION
# PULL REQUEST

## Overview

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
Closes #479 