### PR TITLE
change dependabot schedule to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,5 @@ updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: weekly
-      time: "10:00"
+      interval: monthly
     open-pull-requests-limit: 10


### PR DESCRIPTION
To reduce dependabot noise, we agreed some time ago to change the dependabot schedule to monthly. Critical security updates (as per dependabot default behaviour) will still be opened as soon as they are published (no change there).

